### PR TITLE
Use a relational persistance layer and other things

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,20 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-tomcat</artifactId>
-            <scope>provided</scope>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <!--SpringFox dependencies -->
         <dependency>

--- a/src/main/java/io/swagger/api/ApiException.java
+++ b/src/main/java/io/swagger/api/ApiException.java
@@ -1,0 +1,11 @@
+package io.swagger.api;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
+
+public class ApiException extends Exception{
+	private int code;
+	public ApiException (int code, String msg) {
+		super(msg);
+		this.code = code;
+	}
+}

--- a/src/main/java/io/swagger/api/ApiOriginFilter.java
+++ b/src/main/java/io/swagger/api/ApiOriginFilter.java
@@ -1,0 +1,28 @@
+package io.swagger.api;
+
+import java.io.IOException;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
+
+public class ApiOriginFilter implements javax.servlet.Filter {
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response,
+			FilterChain chain) throws IOException, ServletException {
+		HttpServletResponse res = (HttpServletResponse) response;
+		res.addHeader("Access-Control-Allow-Origin", "*");
+		res.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+		res.addHeader("Access-Control-Allow-Headers", "Content-Type");
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+	}
+}

--- a/src/main/java/io/swagger/api/ApiResponseMessage.java
+++ b/src/main/java/io/swagger/api/ApiResponseMessage.java
@@ -1,0 +1,70 @@
+package io.swagger.api;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
+
+@javax.xml.bind.annotation.XmlRootElement
+public class ApiResponseMessage {
+	public static final int ERROR = 1;
+	public static final int WARNING = 2;
+	public static final int INFO = 3;
+	public static final int OK = 4;
+	public static final int TOO_BUSY = 5;
+
+	int code;
+	String type;
+	String message;
+	
+	public ApiResponseMessage(){}
+	
+	public ApiResponseMessage(int code, String message){
+		this.code = code;
+		switch(code){
+		case ERROR:
+			setType("error");
+			break;
+		case WARNING:
+			setType("warning");
+			break;
+		case INFO:
+			setType("info");
+			break;
+		case OK:
+			setType("ok");
+			break;
+		case TOO_BUSY:
+			setType("too busy");
+			break;
+		default:
+			setType("unknown");
+			break;
+		}
+		this.message = message;
+	}
+
+	@XmlTransient
+	public int getCode() {
+		return code;
+	}
+
+	public void setCode(int code) {
+		this.code = code;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/io/swagger/api/HfcApi.java
+++ b/src/main/java/io/swagger/api/HfcApi.java
@@ -1,46 +1,26 @@
 package io.swagger.api;
 
-import io.swagger.model.CohortData;
-import io.swagger.model.Error;
-import io.swagger.model.HFCurationListResponse;
-import io.swagger.model.HFCurationRequest;
-import io.swagger.model.HFCurationResponse;
-import io.swagger.model.HaplotypeFrequencyData;
-import io.swagger.model.LabelData;
-import io.swagger.model.PopulationData;
-import io.swagger.model.PopulationResponse;
-import io.swagger.model.PopulationSubmissionResponse;
-import io.swagger.model.ScopeData;
+import io.swagger.model.*;
 
 import io.swagger.annotations.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-import javax.validation.constraints.*;
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
 @Api(value = "hfc", description = "the hfc API")
 public interface HfcApi {
 
-    @ApiOperation(value = "", notes = "Gets a list of all submission data sets ", response = HFCurationListResponse.class, tags={  })
+    @ApiOperation(value = "", notes = "Gets a list of all submission data sets ", response = HFCurationResponseList.class, tags={  })
     @ApiResponses(value = { 
-        @ApiResponse(code = 200, message = "Successful response", response = HFCurationListResponse.class),
-        @ApiResponse(code = 500, message = "An unexpected error ocurred", response = HFCurationListResponse.class) })
+        @ApiResponse(code = 200, message = "Successful response", response = HFCurationResponseList.class),
+        @ApiResponse(code = 500, message = "An unexpected error ocurred", response = HFCurationResponseList.class) })
     @RequestMapping(value = "/hfc",
         method = RequestMethod.GET)
-    default ResponseEntity<HFCurationListResponse> hfcGet() {
-        // do some magic!
-        return new ResponseEntity<HFCurationListResponse>(HttpStatus.OK);
-    }
+    ResponseEntity<HFCurationResponseList> hfcGet();
 
 
     @ApiOperation(value = "", notes = "Get a list of all populations ", response = PopulationResponse.class, tags={  })
@@ -49,10 +29,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = PopulationResponse.class) })
     @RequestMapping(value = "/hfc/population",
         method = RequestMethod.GET)
-    default ResponseEntity<PopulationResponse> hfcPopulationGet() {
-        // do some magic!
-        return new ResponseEntity<PopulationResponse>(HttpStatus.OK);
-    }
+    ResponseEntity<PopulationResponse> hfcPopulationGet();
 
 
     @ApiOperation(value = "", notes = "Returns a population with its attached submissions", response = PopulationSubmissionResponse.class, tags={  })
@@ -61,10 +38,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = PopulationSubmissionResponse.class) })
     @RequestMapping(value = "/hfc/population/{populationId}",
         method = RequestMethod.GET)
-    default ResponseEntity<PopulationSubmissionResponse> hfcPopulationPopulationIdGet(@ApiParam(value = "The population id",required=true ) @PathVariable("populationId") String populationId) {
-        // do some magic!
-        return new ResponseEntity<PopulationSubmissionResponse>(HttpStatus.OK);
-    }
+    ResponseEntity<PopulationSubmissionResponse> hfcPopulationPopulationIdGet(@ApiParam(value = "The population id",required=true ) @PathVariable("populationId") String populationId);
 
 
     @ApiOperation(value = "", notes = "Storing of a new Haplotype Frequency set. ", response = HFCurationResponse.class, tags={  })
@@ -73,10 +47,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = HFCurationResponse.class) })
     @RequestMapping(value = "/hfc",
         method = RequestMethod.POST)
-    default ResponseEntity<HFCurationResponse> hfcPost(@ApiParam(value = "Haplotype Frequency Curation Data" ,required=true ) @RequestBody HFCurationRequest hfCurationRequest) {
-        // do some magic!
-        return new ResponseEntity<HFCurationResponse>(HttpStatus.OK);
-    }
+    ResponseEntity<HFCurationResponse> hfcPost(@ApiParam(value = "Haplotype Frequency Curation Data" ,required=true ) @RequestBody HFCurationRequest hfCurationRequest);
 
 
     @ApiOperation(value = "", notes = "Returns the list of haplotypes attached to the given submission", response = CohortData.class, tags={  })
@@ -85,10 +56,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = CohortData.class) })
     @RequestMapping(value = "/hfc/{submissionId}/cohort",
         method = RequestMethod.GET)
-    default ResponseEntity<CohortData> hfcSubmissionIdCohortGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<CohortData>(HttpStatus.OK);
-    }
+    ResponseEntity<CohortData> hfcSubmissionIdCohortGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId);
 
 
     @ApiOperation(value = "", notes = "Returns a submission of haplotypes", response = HFCurationResponse.class, tags={  })
@@ -97,10 +65,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = HFCurationResponse.class) })
     @RequestMapping(value = "/hfc/{submissionId}",
         method = RequestMethod.GET)
-    default ResponseEntity<HFCurationResponse> hfcSubmissionIdGet(@ApiParam(value = "The submission id that the haplotype frequencies were submitted under",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<HFCurationResponse>(HttpStatus.OK);
-    }
+    ResponseEntity<HFCurationResponse> hfcSubmissionIdGet(@ApiParam(value = "The submission id that the haplotype frequencies were submitted under",required=true ) @PathVariable("submissionId") String submissionId);
 
 
     @ApiOperation(value = "", notes = "Returns the list of haplotypes attached to the given submission", response = HaplotypeFrequencyData.class, tags={  })
@@ -109,10 +74,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = HaplotypeFrequencyData.class) })
     @RequestMapping(value = "/hfc/{submissionId}/haplotypes",
         method = RequestMethod.GET)
-    default ResponseEntity<HaplotypeFrequencyData> hfcSubmissionIdHaplotypesGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<HaplotypeFrequencyData>(HttpStatus.OK);
-    }
+    ResponseEntity<HaplotypeFrequencyData> hfcSubmissionIdHaplotypesGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId);
 
 
     @ApiOperation(value = "", notes = "Returns the labels associated to the submission", response = LabelData.class, tags={  })
@@ -121,10 +83,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = LabelData.class) })
     @RequestMapping(value = "/hfc/{submissionId}/labels",
         method = RequestMethod.GET)
-    default ResponseEntity<LabelData> hfcSubmissionIdLabelsGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<LabelData>(HttpStatus.OK);
-    }
+    ResponseEntity<LabelData> hfcSubmissionIdLabelsGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId);
 
 
     @ApiOperation(value = "", notes = "Returns the population of the given submission", response = PopulationData.class, tags={  })
@@ -133,10 +92,7 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = PopulationData.class) })
     @RequestMapping(value = "/hfc/{submissionId}/population",
         method = RequestMethod.GET)
-    default ResponseEntity<PopulationData> hfcSubmissionIdPopulationGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<PopulationData>(HttpStatus.OK);
-    }
+    ResponseEntity<PopulationData> hfcSubmissionIdPopulationGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId);
 
 
     @ApiOperation(value = "", notes = "Returns the scope of the genotypes used for creating the submitted haplotypes", response = ScopeData.class, tags={  })
@@ -145,9 +101,6 @@ public interface HfcApi {
         @ApiResponse(code = 500, message = "An unexpected error ocurred", response = ScopeData.class) })
     @RequestMapping(value = "/hfc/{submissionId}/scope",
         method = RequestMethod.GET)
-    default ResponseEntity<ScopeData> hfcSubmissionIdScopeGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId) {
-        // do some magic!
-        return new ResponseEntity<ScopeData>(HttpStatus.OK);
-    }
+    ResponseEntity<ScopeData> hfcSubmissionIdScopeGet(@ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId);
 
 }

--- a/src/main/java/io/swagger/api/NotFoundException.java
+++ b/src/main/java/io/swagger/api/NotFoundException.java
@@ -1,0 +1,11 @@
+package io.swagger.api;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
+
+public class NotFoundException extends ApiException {
+	private int code;
+	public NotFoundException (int code, String msg) {
+		super(code, msg);
+		this.code = code;
+	}
+}

--- a/src/main/java/io/swagger/model/AccessData.java
+++ b/src/main/java/io/swagger/model/AccessData.java
@@ -5,14 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * AccessData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class AccessData  implements Serializable {
+public class AccessData   {
   @JsonProperty("typeOfAccess")
   private String typeOfAccess = null;
 

--- a/src/main/java/io/swagger/model/CohortData.java
+++ b/src/main/java/io/swagger/model/CohortData.java
@@ -6,14 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.GenotypeList;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * CohortData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class CohortData  implements Serializable {
+public class CohortData   {
   @JsonProperty("GenotypeList")
   private GenotypeList genotypeList = null;
 
@@ -26,8 +25,7 @@ public class CohortData  implements Serializable {
    * Get genotypeList
    * @return genotypeList
   **/
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
+  @ApiModelProperty(value = "")
   public GenotypeList getGenotypeList() {
     return genotypeList;
   }

--- a/src/main/java/io/swagger/model/Error.java
+++ b/src/main/java/io/swagger/model/Error.java
@@ -5,14 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * Error
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class Error  implements Serializable {
+public class Error   {
   @JsonProperty("code")
   private String code = null;
 

--- a/src/main/java/io/swagger/model/FrequencyError.java
+++ b/src/main/java/io/swagger/model/FrequencyError.java
@@ -5,36 +5,34 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.math.BigDecimal;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * FrequencyError
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class FrequencyError  implements Serializable {
+public class FrequencyError   {
   @JsonProperty("value")
-  private BigDecimal value = null;
+  private Double value = null;
 
   @JsonProperty("typeOfError")
   private String typeOfError = null;
 
-  public FrequencyError value(BigDecimal value) {
+  public FrequencyError value(Double value) {
     this.value = value;
     return this;
   }
 
    /**
-   * Get value
+   * value of error
    * @return value
   **/
-  @ApiModelProperty(value = "")
-  public BigDecimal getValue() {
+  @ApiModelProperty(value = "value of error")
+  public Double getValue() {
     return value;
   }
 
-  public void setValue(BigDecimal value) {
+  public void setValue(Double value) {
     this.value = value;
   }
 

--- a/src/main/java/io/swagger/model/Genotype.java
+++ b/src/main/java/io/swagger/model/Genotype.java
@@ -8,14 +8,13 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.GenotypeMethod;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * Genotype
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class Genotype  implements Serializable {
+public class Genotype   {
   @JsonProperty("genotypeString")
   private String genotypeString = null;
 

--- a/src/main/java/io/swagger/model/GenotypeList.java
+++ b/src/main/java/io/swagger/model/GenotypeList.java
@@ -9,15 +9,14 @@ import io.swagger.model.Genotype;
 import io.swagger.model.License;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * List of Genotypes
  */
 @ApiModel(description = "List of Genotypes")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class GenotypeList  implements Serializable {
+public class GenotypeList   {
   @JsonProperty("License")
   private License license = null;
 

--- a/src/main/java/io/swagger/model/GenotypeMethod.java
+++ b/src/main/java/io/swagger/model/GenotypeMethod.java
@@ -6,15 +6,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * GenotypeMethod Record
  */
 @ApiModel(description = "GenotypeMethod Record")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class GenotypeMethod  implements Serializable {
+public class GenotypeMethod   {
   /**
    * Type of method label
    */

--- a/src/main/java/io/swagger/model/HFCurationRequest.java
+++ b/src/main/java/io/swagger/model/HFCurationRequest.java
@@ -2,24 +2,14 @@ package io.swagger.model;
 
 import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.model.AccessData;
-import io.swagger.model.CohortData;
-import io.swagger.model.HaplotypeFrequencyData;
-import io.swagger.model.LabelData;
-import io.swagger.model.MethodData;
-import io.swagger.model.PopulationData;
-import io.swagger.model.ScopeData;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * HFCurationRequest
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class HFCurationRequest  implements Serializable {
+public class HFCurationRequest   {
   @JsonProperty("PopulationID")
   private String populationID = null;
 

--- a/src/main/java/io/swagger/model/HFCurationResponse.java
+++ b/src/main/java/io/swagger/model/HFCurationResponse.java
@@ -5,14 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * HFCurationResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class HFCurationResponse  implements Serializable {
+public class HFCurationResponse   {
   @JsonProperty("SubmissionID")
   private String submissionID = null;
 

--- a/src/main/java/io/swagger/model/HFCurationResponseList.java
+++ b/src/main/java/io/swagger/model/HFCurationResponseList.java
@@ -5,24 +5,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import io.swagger.model.HFCurationResponse;
 import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.*;
 /**
- * HFCurationListResponse
+ * HFCurationResponseList
  */
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class HFCurationListResponse   {
+public class HFCurationResponseList   {
   @JsonProperty("HFCurationResponses")
   private List<HFCurationResponse> hfCurationResponses = new ArrayList<HFCurationResponse>();
 
-  public HFCurationListResponse hfCurationResponses(List<HFCurationResponse> hfCurationResponses) {
+  public HFCurationResponseList hfCurationResponses(List<HFCurationResponse> hfCurationResponses) {
     this.hfCurationResponses = hfCurationResponses;
     return this;
   }
 
-  public HFCurationListResponse addHfCurationResponsesItem(HFCurationResponse hfCurationResponsesItem) {
+  public HFCurationResponseList addHfCurationResponsesItem(HFCurationResponse hfCurationResponsesItem) {
     this.hfCurationResponses.add(hfCurationResponsesItem);
     return this;
   }
@@ -49,8 +50,8 @@ public class HFCurationListResponse   {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    HFCurationListResponse hfCurationListResponse = (HFCurationListResponse) o;
-    return Objects.equals(this.hfCurationResponses, hfCurationListResponse.hfCurationResponses);
+    HFCurationResponseList hfCurationResponseList = (HFCurationResponseList) o;
+    return Objects.equals(this.hfCurationResponses, hfCurationResponseList.hfCurationResponses);
   }
 
   @Override
@@ -61,7 +62,7 @@ public class HFCurationListResponse   {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class HFCurationListResponse {\n");
+    sb.append("class HFCurationResponseList {\n");
     
     sb.append("    hfCurationResponses: ").append(toIndentedString(hfCurationResponses)).append("\n");
     sb.append("}");

--- a/src/main/java/io/swagger/model/HaplotypeFrequency.java
+++ b/src/main/java/io/swagger/model/HaplotypeFrequency.java
@@ -6,22 +6,20 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.FrequencyError;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * HaplotypeFrequency
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class HaplotypeFrequency  implements Serializable {
+public class HaplotypeFrequency   {
   @JsonProperty("haplotypeString")
   private String haplotypeString = null;
 
   @JsonProperty("frequency")
-  private BigDecimal frequency = null;
+  private Double frequency = null;
 
   @JsonProperty("FrequencyErrorList")
   private List<FrequencyError> frequencyErrorList = new ArrayList<FrequencyError>();
@@ -45,22 +43,22 @@ public class HaplotypeFrequency  implements Serializable {
     this.haplotypeString = haplotypeString;
   }
 
-  public HaplotypeFrequency frequency(BigDecimal frequency) {
+  public HaplotypeFrequency frequency(Double frequency) {
     this.frequency = frequency;
     return this;
   }
 
    /**
-   * frequency
+   * value of frequency
    * @return frequency
   **/
-  @ApiModelProperty(required = true, value = "frequency")
+  @ApiModelProperty(required = true, value = "value of frequency")
   @NotNull
-  public BigDecimal getFrequency() {
+  public Double getFrequency() {
     return frequency;
   }
 
-  public void setFrequency(BigDecimal frequency) {
+  public void setFrequency(Double frequency) {
     this.frequency = frequency;
   }
 

--- a/src/main/java/io/swagger/model/HaplotypeFrequencyData.java
+++ b/src/main/java/io/swagger/model/HaplotypeFrequencyData.java
@@ -8,22 +8,21 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.HaplotypeFrequency;
 import io.swagger.model.License;
 import io.swagger.model.Quality;
-import io.swagger.model.ResolutionData;
+import io.swagger.model.ResolutionInfo;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * HaplotypeFrequencyData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class HaplotypeFrequencyData  implements Serializable {
+public class HaplotypeFrequencyData   {
   @JsonProperty("License")
   private License license = null;
 
   @JsonProperty("ResolutionData")
-  private ResolutionData resolutionData = null;
+  private List<ResolutionInfo> resolutionData = new ArrayList<ResolutionInfo>();
 
   @JsonProperty("HaplotypeFrequencyList")
   private List<HaplotypeFrequency> haplotypeFrequencyList = new ArrayList<HaplotypeFrequency>();
@@ -40,8 +39,7 @@ public class HaplotypeFrequencyData  implements Serializable {
    * Get license
    * @return license
   **/
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
+  @ApiModelProperty(value = "")
   public License getLicense() {
     return license;
   }
@@ -50,21 +48,26 @@ public class HaplotypeFrequencyData  implements Serializable {
     this.license = license;
   }
 
-  public HaplotypeFrequencyData resolutionData(ResolutionData resolutionData) {
+  public HaplotypeFrequencyData resolutionData(List<ResolutionInfo> resolutionData) {
     this.resolutionData = resolutionData;
     return this;
   }
 
+  public HaplotypeFrequencyData addResolutionDataItem(ResolutionInfo resolutionDataItem) {
+    this.resolutionData.add(resolutionDataItem);
+    return this;
+  }
+
    /**
-   * Get resolutionData
+   * List of Method
    * @return resolutionData
   **/
-  @ApiModelProperty(value = "")
-  public ResolutionData getResolutionData() {
+  @ApiModelProperty(value = "List of Method")
+  public List<ResolutionInfo> getResolutionData() {
     return resolutionData;
   }
 
-  public void setResolutionData(ResolutionData resolutionData) {
+  public void setResolutionData(List<ResolutionInfo> resolutionData) {
     this.resolutionData = resolutionData;
   }
 

--- a/src/main/java/io/swagger/model/Label.java
+++ b/src/main/java/io/swagger/model/Label.java
@@ -5,15 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * List of Genotypes
  */
 @ApiModel(description = "List of Genotypes")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class Label  implements Serializable {
+public class Label   {
   @JsonProperty("value")
   private String value = null;
 

--- a/src/main/java/io/swagger/model/LabelData.java
+++ b/src/main/java/io/swagger/model/LabelData.java
@@ -5,15 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.model.LabelList;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * LabelData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class LabelData  implements Serializable {
+public class LabelData   {
   @JsonProperty("LabelList")
   private LabelList labelList = null;
 
@@ -26,8 +24,7 @@ public class LabelData  implements Serializable {
    * Get labelList
    * @return labelList
   **/
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
+  @ApiModelProperty(value = "")
   public LabelList getLabelList() {
     return labelList;
   }

--- a/src/main/java/io/swagger/model/LabelList.java
+++ b/src/main/java/io/swagger/model/LabelList.java
@@ -8,15 +8,14 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.Label;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * List of labels
  */
 @ApiModel(description = "List of labels")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class LabelList  implements Serializable {
+public class LabelList   {
   @JsonProperty("Label")
   private List<Label> label = new ArrayList<Label>();
 

--- a/src/main/java/io/swagger/model/License.java
+++ b/src/main/java/io/swagger/model/License.java
@@ -6,15 +6,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * License models, there will be a default license if one is not provided
  */
 @ApiModel(description = "License models, there will be a default license if one is not provided")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class License  implements Serializable {
+public class License   {
   /**
    * Type of creative commons license
    */

--- a/src/main/java/io/swagger/model/Method.java
+++ b/src/main/java/io/swagger/model/Method.java
@@ -6,15 +6,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * Method Record
  */
 @ApiModel(description = "Method Record")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class Method  implements Serializable {
+public class Method   {
   /**
    * Type of method label
    */

--- a/src/main/java/io/swagger/model/MethodData.java
+++ b/src/main/java/io/swagger/model/MethodData.java
@@ -6,14 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.MethodList;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * MethodData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class MethodData  implements Serializable {
+public class MethodData   {
   @JsonProperty("MethodList")
   private MethodList methodList = null;
 
@@ -26,8 +25,7 @@ public class MethodData  implements Serializable {
    * Get methodList
    * @return methodList
   **/
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
+  @ApiModelProperty(value = "")
   public MethodList getMethodList() {
     return methodList;
   }

--- a/src/main/java/io/swagger/model/MethodList.java
+++ b/src/main/java/io/swagger/model/MethodList.java
@@ -5,17 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.model.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * MethodList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class MethodList  implements Serializable {
+public class MethodList   {
   @JsonProperty("Method")
   private List<Method> method = new ArrayList<Method>();
 

--- a/src/main/java/io/swagger/model/PopulationData.java
+++ b/src/main/java/io/swagger/model/PopulationData.java
@@ -5,14 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * PopulationData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class PopulationData  implements Serializable {
+public class PopulationData   {
   @JsonProperty("id")
   private String id = null;
 

--- a/src/main/java/io/swagger/model/PopulationResponse.java
+++ b/src/main/java/io/swagger/model/PopulationResponse.java
@@ -5,17 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.model.PopulationData;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * PopulationResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class PopulationResponse  implements Serializable {
+public class PopulationResponse   {
   @JsonProperty("PopulationList")
   private List<PopulationData> populationList = new ArrayList<PopulationData>();
 

--- a/src/main/java/io/swagger/model/PopulationSubmissionData.java
+++ b/src/main/java/io/swagger/model/PopulationSubmissionData.java
@@ -5,18 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import io.swagger.model.PopulationData;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * Contains all submissions for a population
  */
 @ApiModel(description = "Contains all submissions for a population")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class PopulationSubmissionData  implements Serializable {
+public class PopulationSubmissionData   {
   @JsonProperty("population")
   private PopulationData population = null;
 
@@ -32,8 +30,7 @@ public class PopulationSubmissionData  implements Serializable {
    * Get population
    * @return population
   **/
-  @ApiModelProperty(required = true, value = "")
-  @NotNull
+  @ApiModelProperty(value = "")
   public PopulationData getPopulation() {
     return population;
   }

--- a/src/main/java/io/swagger/model/PopulationSubmissionResponse.java
+++ b/src/main/java/io/swagger/model/PopulationSubmissionResponse.java
@@ -8,14 +8,13 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.PopulationSubmissionData;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * PopulationSubmissionResponse
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class PopulationSubmissionResponse  implements Serializable {
+public class PopulationSubmissionResponse   {
   @JsonProperty("PopulationSubmissionList")
   private List<PopulationSubmissionData> populationSubmissionList = new ArrayList<PopulationSubmissionData>();
 

--- a/src/main/java/io/swagger/model/Quality.java
+++ b/src/main/java/io/swagger/model/Quality.java
@@ -6,17 +6,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.math.BigDecimal;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * Quality
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class Quality  implements Serializable {
+public class Quality   {
   @JsonProperty("value")
-  private BigDecimal value = null;
+  private Double value = null;
 
   /**
    * type of quality
@@ -88,22 +86,22 @@ public class Quality  implements Serializable {
   @JsonProperty("typeOfQuality")
   private TypeOfQualityEnum typeOfQuality = null;
 
-  public Quality value(BigDecimal value) {
+  public Quality value(Double value) {
     this.value = value;
     return this;
   }
 
    /**
-   * label name
+   * value of quality
    * @return value
   **/
-  @ApiModelProperty(required = true, value = "label name")
+  @ApiModelProperty(required = true, value = "value of quality")
   @NotNull
-  public BigDecimal getValue() {
+  public Double getValue() {
     return value;
   }
 
-  public void setValue(BigDecimal value) {
+  public void setValue(Double value) {
     this.value = value;
   }
 

--- a/src/main/java/io/swagger/model/ResolutionData.java
+++ b/src/main/java/io/swagger/model/ResolutionData.java
@@ -5,15 +5,14 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.model.ResolutionInfo;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * List of Method
  */
 @ApiModel(description = "List of Method")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class ResolutionData extends ArrayList<ResolutionInfo> implements Serializable {
+public class ResolutionData extends ArrayList<ResolutionInfo>  {
 
   @Override
   public boolean equals(java.lang.Object o) {

--- a/src/main/java/io/swagger/model/ResolutionInfo.java
+++ b/src/main/java/io/swagger/model/ResolutionInfo.java
@@ -6,14 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * ResolutionInfo
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class ResolutionInfo  implements Serializable {
+public class ResolutionInfo   {
   @JsonProperty("scopeElement")
   private String scopeElement = null;
 

--- a/src/main/java/io/swagger/model/ScopeData.java
+++ b/src/main/java/io/swagger/model/ScopeData.java
@@ -8,14 +8,13 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.model.ScopeElement;
 import java.util.ArrayList;
 import java.util.List;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * ScopeData
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class ScopeData  implements Serializable {
+public class ScopeData   {
   @JsonProperty("ScopeElement")
   private List<ScopeElement> scopeElement = new ArrayList<ScopeElement>();
 

--- a/src/main/java/io/swagger/model/ScopeElement.java
+++ b/src/main/java/io/swagger/model/ScopeElement.java
@@ -6,14 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.io.Serializable;
 import javax.validation.constraints.*;
 /**
  * ScopeElement
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-26T11:57:21.787-05:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-05-30T13:04:33.940Z")
 
-public class ScopeElement  implements Serializable {
+public class ScopeElement   {
   @JsonProperty("name")
   private String name = null;
 

--- a/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
+++ b/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
@@ -2,13 +2,9 @@ package org.nmdp.hfcus.controller;
 
 import io.swagger.annotations.ApiParam;
 import io.swagger.api.HfcApi;
-import io.swagger.model.HFCurationListResponse;
-import io.swagger.model.HFCurationRequest;
-import io.swagger.model.HFCurationResponse;
-import io.swagger.model.HaplotypeFrequencyData;
-import org.nmdp.hfcus.dao.HFCurationRepository;
-import org.nmdp.hfcus.model.HFCuration;
-import org.springframework.beans.BeanUtils;
+import io.swagger.model.*;
+import org.nmdp.hfcus.dao.*;
+import org.nmdp.hfcus.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,29 +12,44 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
 public class HFCurationApiController implements HfcApi{
 
-    private HFCurationRepository curationRepository;
+    private final RepositoryContainer repositoryContainer;
 
     @Autowired
-    public HFCurationApiController(HFCurationRepository curationRepository) {
-        this.curationRepository = curationRepository;
+    public HFCurationApiController(
+            HFCurationRepository curationRepository,
+            PopulationRepository populationRepository,
+            CohortRepository cohortRepository,
+            MethodSetRepository methodSetRepository,
+            LabelSetRepository labelSetRepository,
+            HaplotypeFrequencySetRepository haplotypeFrequencySetRepository,
+            AccessRepository accessRepository,
+            ScopeListRepository scopeListRepository
+    ) {
+        this.repositoryContainer = new RepositoryContainer();
+        repositoryContainer.setCurationRepository(curationRepository);
+        repositoryContainer.setPopulationRepository(populationRepository);
+        repositoryContainer.setCohortRepository(cohortRepository);
+        repositoryContainer.setMethodSetRepository(methodSetRepository);
+        repositoryContainer.setLabelSetRepository(labelSetRepository);
+        repositoryContainer.setHaplotypeFrequencySetRepository(haplotypeFrequencySetRepository);
+        repositoryContainer.setAccessRepository(accessRepository);
+        repositoryContainer.setScopeListRepository(scopeListRepository);
     }
 
     @Override
-    public ResponseEntity<HFCurationListResponse> hfcGet() {
+    public ResponseEntity<HFCurationResponseList> hfcGet() {
 
-        HFCurationListResponse response = new HFCurationListResponse();
+        HFCurationResponseList response = new HFCurationResponseList();
 
-        List<HFCuration> curations = curationRepository.findAll();
+        Iterable<HFCuration> curations = repositoryContainer.getCurationRepository().findAll();
         for (HFCuration curation : curations) {
-            HFCurationResponse hfCurationResponse = new HFCurationResponse();
-            BeanUtils.copyProperties(curation, hfCurationResponse);
-            hfCurationResponse.submissionID(curation.getId());
-            response.addHfCurationResponsesItem(hfCurationResponse);
+            response.addHfCurationResponsesItem(curation.toSwaggerObject());
         }
 
         return ResponseEntity.ok(response);
@@ -47,13 +58,9 @@ public class HFCurationApiController implements HfcApi{
     @Override
     public ResponseEntity<HFCurationResponse> hfcPost(@RequestBody HFCurationRequest hfCurationRequest) {
         if (hfCurationRequest != null) {
-            HFCuration curation = new HFCuration();
-            BeanUtils.copyProperties(hfCurationRequest, curation);
-            curation = curationRepository.save(curation);
-            HFCurationResponse response = new HFCurationResponse();
-            BeanUtils.copyProperties(curation, response);
-            response.submissionID(curation.getId());
-            return ResponseEntity.ok(response);
+            HFCuration curation = new HFCuration(repositoryContainer, hfCurationRequest);
+            curation = repositoryContainer.getCurationRepository().save(curation);
+            return ResponseEntity.ok(curation.toSwaggerObject());
         }
 
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -63,8 +70,75 @@ public class HFCurationApiController implements HfcApi{
     public ResponseEntity<HaplotypeFrequencyData> hfcSubmissionIdHaplotypesGet(
             @ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId
     ){
-        HFCuration curation = curationRepository.findOne(submissionId);
-        HaplotypeFrequencyData response = curation.getHaplotypeFrequencyData();
+        HFCuration curation = repositoryContainer.getCurationRepository().findOne(submissionId);
+        return ResponseEntity.ok(curation.getHaplotypeFrequencyData().toSwaggerObject());
+    }
+
+    @Override
+    public ResponseEntity<PopulationResponse> hfcPopulationGet() {
+        PopulationResponse response = new PopulationResponse();
+
+        Iterable<Population> populations = repositoryContainer.getPopulationRepository().findAll();
+        for (Population data: populations){
+            response.addPopulationListItem(data.toSwaggerObject());
+        }
         return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<PopulationSubmissionResponse> hfcPopulationPopulationIdGet(
+            @ApiParam(value = "The populationId id",required=true ) @PathVariable("populationId") String populationId
+    ) {
+        PopulationSubmissionResponse response = new PopulationSubmissionResponse();
+        Iterable<HFCuration> curations = repositoryContainer.getCurationRepository().findBypopulationDataId(populationId);
+        PopulationSubmissionData pop = new PopulationSubmissionData();
+        Population population = repositoryContainer.getPopulationRepository().findOne(populationId);
+        pop.setPopulation(population.toSwaggerObject());
+        List<String> subs = new ArrayList<>();
+        for (HFCuration curation: curations) {
+            subs.add(curation.getId());
+        }
+        pop.setSubmissions(subs);
+        response.addPopulationSubmissionListItem(pop);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<CohortData> hfcSubmissionIdCohortGet(
+            @ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId
+    ) {
+        Cohort cohort = repositoryContainer.getCurationRepository().findOne(submissionId).getCohortData();
+        return ResponseEntity.ok(cohort.toSwaggerObject());
+    }
+
+    @Override
+    public ResponseEntity<HFCurationResponse> hfcSubmissionIdGet(
+            @ApiParam(value = "The submission id that the haplotype frequencies were submitted under",required=true ) @PathVariable("submissionId") String submissionId
+    ) {
+        return ResponseEntity.ok(repositoryContainer.getCurationRepository().findOne(submissionId).toSwaggerObject());
+    }
+
+    @Override
+    public ResponseEntity<LabelData> hfcSubmissionIdLabelsGet(
+            @ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId
+    ) {
+        LabelSet label = repositoryContainer.getCurationRepository().findOne(submissionId).getLabelData();
+        return ResponseEntity.ok(label.toSwaggerObject());
+    }
+
+    @Override
+    public ResponseEntity<PopulationData> hfcSubmissionIdPopulationGet(
+            @ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId
+    ) {
+        Population population = repositoryContainer.getCurationRepository().findOne(submissionId).getPopulationData();
+        return ResponseEntity.ok(population.toSwaggerObject());
+    }
+
+    @Override
+    public ResponseEntity<ScopeData> hfcSubmissionIdScopeGet(
+            @ApiParam(value = "The submission id",required=true ) @PathVariable("submissionId") String submissionId
+    ) {
+        ScopeList scopeList = repositoryContainer.getCurationRepository().findOne(submissionId).getScopeData();
+        return ResponseEntity.ok(scopeList.toSwaggerObject());
     }
 }

--- a/src/main/java/org/nmdp/hfcus/dao/AccessRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/AccessRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.Access;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AccessRepository extends CrudRepository<Access, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/CohortRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/CohortRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.Cohort;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CohortRepository extends CrudRepository<Cohort, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/HFCurationRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/HFCurationRepository.java
@@ -1,7 +1,8 @@
 package org.nmdp.hfcus.dao;
 
 import org.nmdp.hfcus.model.HFCuration;
-import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.CrudRepository;
 
-public interface HFCurationRepository  extends MongoRepository <HFCuration, String> {
+public interface HFCurationRepository  extends CrudRepository<HFCuration, String> {
+    Iterable<HFCuration> findBypopulationDataId(String populationId);
 }

--- a/src/main/java/org/nmdp/hfcus/dao/HaplotypeFrequencySetRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/HaplotypeFrequencySetRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.HaplotypeFrequencySet;
+import org.springframework.data.repository.CrudRepository;
+
+public interface HaplotypeFrequencySetRepository extends CrudRepository<HaplotypeFrequencySet, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/LabelSetRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/LabelSetRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.LabelSet;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LabelSetRepository extends CrudRepository<LabelSet, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/MethodSetRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/MethodSetRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.MethodSet;
+import org.springframework.data.repository.CrudRepository;
+
+public interface MethodSetRepository extends CrudRepository<MethodSet, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/PopulationRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/PopulationRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.Population;
+import org.springframework.data.repository.CrudRepository;
+
+public interface PopulationRepository extends CrudRepository<Population, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/dao/RepositoryContainer.java
+++ b/src/main/java/org/nmdp/hfcus/dao/RepositoryContainer.java
@@ -1,0 +1,79 @@
+package org.nmdp.hfcus.dao;
+
+import org.springframework.data.repository.CrudRepository;
+
+public class RepositoryContainer {
+
+    private HFCurationRepository curationRepository;
+    private PopulationRepository populationRepository;
+    private CohortRepository cohortRepository;
+    private MethodSetRepository methodSetRepository;
+    private LabelSetRepository labelSetRepository;
+    private HaplotypeFrequencySetRepository haplotypeFrequencySetRepository;
+    private AccessRepository accessRepository;
+    private ScopeListRepository scopeListRepository;
+
+    public HFCurationRepository getCurationRepository() {
+        return curationRepository;
+    }
+
+    public void setCurationRepository(HFCurationRepository curationRepository) {
+        this.curationRepository = curationRepository;
+    }
+
+    public PopulationRepository getPopulationRepository() {
+        return populationRepository;
+    }
+
+    public void setPopulationRepository(PopulationRepository populationRepository) {
+        this.populationRepository = populationRepository;
+    }
+
+    public CohortRepository getCohortRepository() {
+        return cohortRepository;
+    }
+
+    public void setCohortRepository(CohortRepository cohortRepository) {
+        this.cohortRepository = cohortRepository;
+    }
+
+    public MethodSetRepository getMethodSetRepository() {
+        return methodSetRepository;
+    }
+
+    public void setMethodSetRepository(MethodSetRepository methodSetRepository) {
+        this.methodSetRepository = methodSetRepository;
+    }
+
+    public LabelSetRepository getLabelSetRepository() {
+        return labelSetRepository;
+    }
+
+    public void setLabelSetRepository(LabelSetRepository labelSetRepository) {
+        this.labelSetRepository = labelSetRepository;
+    }
+
+    public HaplotypeFrequencySetRepository getHaplotypeFrequencySetRepository() {
+        return haplotypeFrequencySetRepository;
+    }
+
+    public void setHaplotypeFrequencySetRepository(HaplotypeFrequencySetRepository haplotypeFrequencySetRepository) {
+        this.haplotypeFrequencySetRepository = haplotypeFrequencySetRepository;
+    }
+
+    public AccessRepository getAccessRepository() {
+        return accessRepository;
+    }
+
+    public void setAccessRepository(AccessRepository accessRepository) {
+        this.accessRepository = accessRepository;
+    }
+
+    public ScopeListRepository getScopeListRepository() {
+        return scopeListRepository;
+    }
+
+    public void setScopeListRepository(ScopeListRepository scopeListRepository) {
+        this.scopeListRepository = scopeListRepository;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/dao/ScopeListRepository.java
+++ b/src/main/java/org/nmdp/hfcus/dao/ScopeListRepository.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.dao;
+
+import org.nmdp.hfcus.model.ScopeList;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ScopeListRepository extends CrudRepository<ScopeList, String> {
+}

--- a/src/main/java/org/nmdp/hfcus/model/Access.java
+++ b/src/main/java/org/nmdp/hfcus/model/Access.java
@@ -1,0 +1,46 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.AccessData;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Access {
+    public Access(){
+        //intentionally left empty
+    }
+
+    public Access(AccessData swaggerObject) {
+        typeOfAccess = swaggerObject.getTypeOfAccess();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private String typeOfAccess;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTypeOfAccess() {
+        return typeOfAccess;
+    }
+
+    public void setTypeOfAccess(String typeOfAccess) {
+        this.typeOfAccess = typeOfAccess;
+    }
+
+    public AccessData toSwaggerObject(){
+        AccessData data = new AccessData();
+        data.setTypeOfAccess(typeOfAccess);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Cohort.java
+++ b/src/main/java/org/nmdp/hfcus/model/Cohort.java
@@ -1,0 +1,48 @@
+package org.nmdp.hfcus.model;
+
+
+import io.swagger.model.CohortData;
+
+import javax.persistence.*;
+
+@Entity
+public class Cohort {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    @OneToOne(cascade = CascadeType.ALL)
+    private GenotypeList genotypeList;
+
+    public Cohort(){
+        //intentionally left empty
+    }
+
+    public Cohort(CohortData swaggerObject){
+        if (swaggerObject.getGenotypeList() != null) {
+            genotypeList = new GenotypeList(swaggerObject.getGenotypeList());
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public GenotypeList getGenotypeList() {
+        return genotypeList;
+    }
+
+    public void setGenotypeList(GenotypeList genotypeList) {
+        this.genotypeList = genotypeList;
+    }
+
+    public CohortData toSwaggerObject(){
+        CohortData data = new CohortData();
+        data.setGenotypeList(genotypeList.toSwaggerObject());
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/FrequencyError.java
+++ b/src/main/java/org/nmdp/hfcus/model/FrequencyError.java
@@ -1,0 +1,56 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.math.BigDecimal;
+
+@Entity
+public class FrequencyError {
+    public FrequencyError(){
+        //intentionally left empty
+    }
+
+    public FrequencyError(io.swagger.model.FrequencyError error) {
+        value = error.getValue();
+        typeOfError = error.getTypeOfError();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private Double value;
+    private String typeOfError;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(Double value) {
+        this.value = value;
+    }
+
+    public String getTypeOfError() {
+        return typeOfError;
+    }
+
+    public void setTypeOfError(String typeOfError) {
+        this.typeOfError = typeOfError;
+    }
+
+    public io.swagger.model.FrequencyError toSwaggerObject(){
+        io.swagger.model.FrequencyError data = new io.swagger.model.FrequencyError();
+        data.setValue(value);
+        data.setTypeOfError(typeOfError);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Genotype.java
+++ b/src/main/java/org/nmdp/hfcus/model/Genotype.java
@@ -1,0 +1,67 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Genotype {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String genotypeId;
+    private String genotypeString;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<GenotypeMethod> genotypingMethods;
+
+    public Genotype(){
+        //intentionally left empty
+    }
+
+    public Genotype(io.swagger.model.Genotype swaggerObject){
+        genotypeString = swaggerObject.getGenotypeString();
+        if (swaggerObject.getGenotypingMethods() != null){
+            genotypingMethods = new ArrayList<>();
+            for (io.swagger.model.GenotypeMethod method :swaggerObject.getGenotypingMethods()) {
+                genotypingMethods.add(new GenotypeMethod(method));
+            }
+        }
+    }
+
+    public String getGenotypeId() {
+        return genotypeId;
+    }
+
+    public void setGenotypeId(String genotypeId) {
+        this.genotypeId = genotypeId;
+    }
+
+    public String getGenotypeString() {
+        return genotypeString;
+    }
+
+    public void setGenotypeString(String genotypeString) {
+        this.genotypeString = genotypeString;
+    }
+
+    public List<GenotypeMethod> getGenotypingMethods() {
+        return genotypingMethods;
+    }
+
+    public void setGenotypingMethods(List<GenotypeMethod> genotypingMethods) {
+        this.genotypingMethods = genotypingMethods;
+    }
+
+    public io.swagger.model.Genotype toSwaggerObject(){
+        io.swagger.model.Genotype data = new io.swagger.model.Genotype();
+        data.setGenotypeString(genotypeString);
+        if (genotypingMethods != null){
+            List<io.swagger.model.GenotypeMethod> methods = new ArrayList<>();
+            for (GenotypeMethod method: genotypingMethods) {
+                methods.add(method.toSwaggerObject());
+            }
+            data.setGenotypingMethods(methods);
+        }
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/GenotypeList.java
+++ b/src/main/java/org/nmdp/hfcus/model/GenotypeList.java
@@ -1,0 +1,73 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.License;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class GenotypeList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private License.TypeOfLicenseEnum license;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Genotype> genotypeList;
+
+    public GenotypeList(){
+        //intentionallyLeftEmpty
+    }
+
+    public GenotypeList(io.swagger.model.GenotypeList swaggerObject){
+        if (swaggerObject.getLicense() != null) {
+            license = swaggerObject.getLicense().getTypeOfLicense();
+        }
+        genotypeList = new ArrayList<>();
+        if (swaggerObject.getGenotype() != null) {
+            for (io.swagger.model.Genotype genotype : swaggerObject.getGenotype()) {
+                genotypeList.add(new Genotype(genotype));
+            }
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public License.TypeOfLicenseEnum getLicense() {
+        return license;
+    }
+
+    public void setLicense(License.TypeOfLicenseEnum license) {
+        this.license = license;
+    }
+
+    public List<Genotype> getGenotypeList() {
+        return genotypeList;
+    }
+
+    public void setGenotypeList(List<Genotype> genotypeList) {
+        this.genotypeList = genotypeList;
+    }
+
+    public io.swagger.model.GenotypeList toSwaggerObject(){
+        io.swagger.model.GenotypeList data = new io.swagger.model.GenotypeList();
+        if (license != null) {
+            License lic = new License();
+            lic.setTypeOfLicense(license);
+            data.setLicense(lic);
+        }
+        List<io.swagger.model.Genotype> swaggerGenotypeList = new ArrayList<>();
+        for (Genotype genotype: genotypeList) {
+            swaggerGenotypeList.add(genotype.toSwaggerObject());
+        }
+        data.setGenotype(swaggerGenotypeList);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/GenotypeMethod.java
+++ b/src/main/java/org/nmdp/hfcus/model/GenotypeMethod.java
@@ -1,0 +1,79 @@
+package org.nmdp.hfcus.model;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class GenotypeMethod {
+
+    public GenotypeMethod(){
+        //intentionally left empty
+    }
+
+    public GenotypeMethod(io.swagger.model.GenotypeMethod swaggerObject){
+        methodLabel = swaggerObject.getMethodLabel();
+        methodValue = swaggerObject.getMethodValue();
+        methodComment = swaggerObject.getMethodComment();
+        methoReference = swaggerObject.getMethodReference();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private io.swagger.model.GenotypeMethod.MethodLabelEnum methodLabel;
+    private String methodValue;
+    private String methodComment;
+    private String methoReference;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public io.swagger.model.GenotypeMethod.MethodLabelEnum getMethodLabel() {
+        return methodLabel;
+    }
+
+    public void setMethodLabel(io.swagger.model.GenotypeMethod.MethodLabelEnum methodLabel) {
+        this.methodLabel = methodLabel;
+    }
+
+    public String getMethodValue() {
+        return methodValue;
+    }
+
+    public void setMethodValue(String methodValue) {
+        this.methodValue = methodValue;
+    }
+
+    public String getMethodComment() {
+        return methodComment;
+    }
+
+    public void setMethodComment(String methodComment) {
+        this.methodComment = methodComment;
+    }
+
+    public String getMethoReference() {
+        return methoReference;
+    }
+
+    public void setMethoReference(String methoReference) {
+        this.methoReference = methoReference;
+    }
+
+    public io.swagger.model.GenotypeMethod toSwaggerObject(){
+        io.swagger.model.GenotypeMethod data = new io.swagger.model.GenotypeMethod();
+        data.setMethodLabel(methodLabel);
+        data.setMethodValue(methodValue);
+        data.setMethodComment(methodComment);
+        data.setMethodReference(methoReference);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/HFCuration.java
+++ b/src/main/java/org/nmdp/hfcus/model/HFCuration.java
@@ -1,50 +1,88 @@
 package org.nmdp.hfcus.model;
 
-import io.swagger.model.AccessData;
-import io.swagger.model.CohortData;
-import io.swagger.model.HaplotypeFrequencyData;
-import io.swagger.model.LabelData;
-import io.swagger.model.MethodData;
-import io.swagger.model.PopulationData;
-import io.swagger.model.ScopeData;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Document;
+import io.swagger.model.*;
+import org.nmdp.hfcus.dao.RepositoryContainer;
+
+import javax.persistence.*;
 
 import java.io.Serializable;
+import java.util.Objects;
 
-@Document(collection = "HFCuration")
+@Entity
 public class HFCuration implements Serializable {
 
+    public HFCuration(){
+        // intentionally left empty
+    }
+
+    public HFCuration(RepositoryContainer repositoryContainer, HFCurationRequest data){
+        if (data.getPopulationData() != null){
+            populationData = new Population(data.getPopulationData());
+        }else if (data.getPopulationID() != null && !Objects.equals(data.getPopulationID(), "")){
+            populationData = repositoryContainer.getPopulationRepository().findOne(data.getPopulationID());
+        }
+
+        if (data.getCohortData() != null){
+            cohortData = new Cohort(data.getCohortData());
+        }else if (data.getCohortData() != null && !Objects.equals(data.getCohortID(), "")){
+            cohortData = repositoryContainer.getCohortRepository().findOne(data.getCohortID());
+        }
+
+        if (data.getMethodData() != null){
+            methodData = new MethodSet(data.getMethodData());
+        }else if (data.getMethodSetID() != null && !Objects.equals(data.getMethodSetID(), "")){
+            methodData = repositoryContainer.getMethodSetRepository().findOne(data.getMethodSetID());
+        }
+
+        if (data.getLabelData() != null){
+            labelData = new LabelSet(data.getLabelData());
+        }else if (data.getLabelID() != null && !Objects.equals(data.getLabelID(), "")){
+            labelData = repositoryContainer.getLabelSetRepository().findOne(data.getLabelID());
+        }
+
+        if (data.getHaplotypeFrequencyData() != null){
+            haplotypeFrequencyData = new HaplotypeFrequencySet(data.getHaplotypeFrequencyData());
+        }else if (data.getHaplotypeFrequencyDataID() != null && !Objects.equals(data.getHaplotypeFrequencyDataID(), "")){
+            haplotypeFrequencyData = repositoryContainer.getHaplotypeFrequencySetRepository().findOne(data.getHaplotypeFrequencyDataID());
+        }
+
+        if (data.getAccessData() != null){
+            accessData = new Access(data.getAccessData());
+        }else if (data.getAccessID() != null && !Objects.equals(data.getAccessID(), "")){
+            accessData = repositoryContainer.getAccessRepository().findOne(data.getAccessID());
+        }
+
+        if (data.getScopeData() != null){
+            scopeData = new ScopeList(data.getScopeData());
+        }else if (data.getScopeID() != null && !Objects.equals(data.getScopeID(), "")){
+            scopeData = repositoryContainer.getScopeListRepository().findOne(data.getScopeID());
+        }
+    }
+
     @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
     private String id;
 
-    private String populationID;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private Population populationData;
 
-    private PopulationData populationData;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private Cohort cohortData;
 
-    private String cohortID;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private MethodSet methodData;
 
-    private CohortData cohortData;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private LabelSet labelData;
 
-    private String methodSetID;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private HaplotypeFrequencySet haplotypeFrequencyData;
 
-    private MethodData methodData;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private ScopeList scopeData;
 
-    private String labelID;
-
-    private LabelData labelData;
-
-    private String haplotypeFrequencyDataID;
-
-    private HaplotypeFrequencyData haplotypeFrequencyData;
-
-    private String scopeID;
-
-    private ScopeData scopeData;
-
-    private String accessID;
-
-    private AccessData accessData;
+    @ManyToOne(cascade = CascadeType.ALL)
+    private Access accessData;
 
     public String getId() {
         return id;
@@ -54,115 +92,86 @@ public class HFCuration implements Serializable {
         this.id = id;
     }
 
-    public String getPopulationID() {
-        return populationID;
-    }
-
-    public void setPopulationID(String populationID) {
-        this.populationID = populationID;
-    }
-
-    public PopulationData getPopulationData() {
+    public Population getPopulationData() {
         return populationData;
     }
 
-    public void setPopulationData(PopulationData populationData) {
+    public void setPopulationData(Population populationData) {
         this.populationData = populationData;
     }
 
-    public String getCohortID() {
-        return cohortID;
-    }
-
-    public void setCohortID(String cohortID) {
-        this.cohortID = cohortID;
-    }
-
-    public CohortData getCohortData() {
+    public Cohort getCohortData() {
         return cohortData;
     }
 
-    public void setCohortData(CohortData cohortData) {
+    public void setCohortData(Cohort cohortData) {
         this.cohortData = cohortData;
     }
 
-    public String getMethodSetID() {
-        return methodSetID;
-    }
-
-    public void setMethodSetID(String methodSetID) {
-        this.methodSetID = methodSetID;
-    }
-
-    public MethodData getMethodData() {
+    public MethodSet getMethodData() {
         return methodData;
     }
 
-    public void setMethodData(MethodData methodData) {
+    public void setMethodData(MethodSet methodData) {
         this.methodData = methodData;
     }
 
-    public String getLabelID() {
-        return labelID;
-    }
-
-    public void setLabelID(String labelID) {
-        this.labelID = labelID;
-    }
-
-    public LabelData getLabelData() {
+    public LabelSet getLabelData() {
         return labelData;
     }
 
-    public void setLabelData(LabelData labelData) {
+    public void setLabelData(LabelSet labelData) {
         this.labelData = labelData;
     }
 
-    public String getHaplotypeFrequencyDataID() {
-        return haplotypeFrequencyDataID;
-    }
-
-    public void setHaplotypeFrequencyDataID(String haplotypeFrequencyDataID) {
-        this.haplotypeFrequencyDataID = haplotypeFrequencyDataID;
-    }
-
-    public HaplotypeFrequencyData getHaplotypeFrequencyData() {
+    public HaplotypeFrequencySet getHaplotypeFrequencyData() {
         return haplotypeFrequencyData;
     }
 
-    public void setHaplotypeFrequencyData(HaplotypeFrequencyData haplotypeFrequencyData) {
+    public void setHaplotypeFrequencyData(HaplotypeFrequencySet haplotypeFrequencyData) {
         this.haplotypeFrequencyData = haplotypeFrequencyData;
     }
 
-    public String getScopeID() {
-        return scopeID;
-    }
-
-    public void setScopeID(String scopeID) {
-        this.scopeID = scopeID;
-    }
-
-    public ScopeData getScopeData() {
+    public ScopeList getScopeData() {
         return scopeData;
     }
 
-    public void setScopeData(ScopeData scopeData) {
+    public void setScopeData(ScopeList scopeData) {
         this.scopeData = scopeData;
     }
 
-    public String getAccessID() {
-        return accessID;
-    }
-
-    public void setAccessID(String accessID) {
-        this.accessID = accessID;
-    }
-
-    public AccessData getAccessData() {
+    public Access getAccessData() {
         return accessData;
     }
 
-    public void setAccessData(AccessData accessData) {
+    public void setAccessData(Access accessData) {
         this.accessData = accessData;
+    }
+
+    public HFCurationResponse toSwaggerObject(){
+        HFCurationResponse data = new HFCurationResponse();
+        data.setSubmissionID(id);
+        if (populationData != null){
+            data.setPopulationID(populationData.getId());
+        }
+        if(cohortData != null){
+            data.setCohortID(cohortData.getId());
+        }
+        if (methodData != null){
+            data.setMethodSetID(methodData.getId());
+        }
+        if (labelData != null){
+            data.setLabelID(labelData.getId());
+        }
+        if (haplotypeFrequencyData != null){
+            data.setHaplotypeListID(haplotypeFrequencyData.getId());
+        }
+        if (scopeData != null){
+            data.setScopeID(scopeData.getId());
+        }
+        if (accessData != null){
+            data.setAccessID(accessData.getId());
+        }
+        return data;
     }
 }

--- a/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequency.java
+++ b/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequency.java
@@ -1,0 +1,77 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class HaplotypeFrequency {
+    public HaplotypeFrequency(){
+        //intentionally left empty
+    }
+    public HaplotypeFrequency(io.swagger.model.HaplotypeFrequency swaggerObject) {
+        haplotypeString = swaggerObject.getHaplotypeString();
+        frequency = swaggerObject.getFrequency();
+        if (swaggerObject.getFrequencyErrorList() != null){
+            errorList = new ArrayList<>();
+            for (io.swagger.model.FrequencyError error: swaggerObject.getFrequencyErrorList()) {
+                errorList.add(new FrequencyError(error));
+            }
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private String haplotypeString;
+    private Double frequency;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<FrequencyError> errorList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getHaplotypeString() {
+        return haplotypeString;
+    }
+
+    public void setHaplotypeString(String haplotypeString) {
+        this.haplotypeString = haplotypeString;
+    }
+
+    public Double getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(Double frequency) {
+        this.frequency = frequency;
+    }
+
+    public List<FrequencyError> getErrorList() {
+        return errorList;
+    }
+
+    public void setErrorList(List<FrequencyError> errorList) {
+        this.errorList = errorList;
+    }
+
+    public io.swagger.model.HaplotypeFrequency toSwaggerObject(){
+        io.swagger.model.HaplotypeFrequency data = new io.swagger.model.HaplotypeFrequency();
+        data.setHaplotypeString(haplotypeString);
+        data.setFrequency(frequency);
+        if (errorList != null){
+            List<io.swagger.model.FrequencyError> errors = new ArrayList<>();
+            for (FrequencyError error: errorList) {
+                errors.add(error.toSwaggerObject());
+            }
+            data.setFrequencyErrorList(errors);
+        }
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequencySet.java
+++ b/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequencySet.java
@@ -1,0 +1,116 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.HaplotypeFrequencyData;
+import io.swagger.model.License;
+import io.swagger.model.ResolutionData;
+import io.swagger.model.ResolutionInfo;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class HaplotypeFrequencySet {
+    public HaplotypeFrequencySet(){
+        //intentionally left empty
+    }
+
+    public HaplotypeFrequencySet(HaplotypeFrequencyData swaggerObject){
+        license = swaggerObject.getLicense().getTypeOfLicense();
+        if (swaggerObject.getResolutionData() != null) {
+            resolutionList = new ArrayList<>();
+            for (ResolutionInfo resolutionInfo :swaggerObject.getResolutionData()) {
+                resolutionList.add(new Resolution(resolutionInfo));
+            }
+        }
+        frequencyList = new ArrayList<>();
+        for (io.swagger.model.HaplotypeFrequency frequency: swaggerObject.getHaplotypeFrequencyList()) {
+            frequencyList.add(new HaplotypeFrequency(frequency));
+        }
+        if (swaggerObject.getQualityList() != null){
+            qualityList = new ArrayList<>();
+            for (io.swagger.model.Quality quality: swaggerObject.getQualityList()) {
+                qualityList.add(new Quality(quality));
+            }
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private License.TypeOfLicenseEnum license;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Resolution> resolutionList;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<HaplotypeFrequency> frequencyList;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Quality> qualityList;
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public License.TypeOfLicenseEnum getLicense() {
+        return license;
+    }
+
+    public void setLicense(License.TypeOfLicenseEnum license) {
+        this.license = license;
+    }
+
+    public List<Resolution> getResolution() {
+        return resolutionList;
+    }
+
+    public void setResolution(List<Resolution> resolutionList) {
+        this.resolutionList = resolutionList;
+    }
+
+    public List<HaplotypeFrequency> getFrequencyList() {
+        return frequencyList;
+    }
+
+    public void setFrequencyList(List<HaplotypeFrequency> frequencyList) {
+        this.frequencyList = frequencyList;
+    }
+
+    public List<Quality> getQualityList() {
+        return qualityList;
+    }
+
+    public void setQualityList(List<Quality> qualityList) {
+        this.qualityList = qualityList;
+    }
+
+    public HaplotypeFrequencyData toSwaggerObject(){
+        HaplotypeFrequencyData data = new HaplotypeFrequencyData();
+        License license = new License();
+        license.setTypeOfLicense(this.license);
+        data.setLicense(license);
+        if (resolutionList != null){
+            ResolutionData resolutions = new ResolutionData();
+            for (Resolution resolution: resolutionList) {
+                resolutions.add(resolution.toSwaggerObject());
+            }
+            data.setResolutionData(resolutions);
+        }
+        List<io.swagger.model.HaplotypeFrequency> frequencies = new ArrayList<>();
+        for (HaplotypeFrequency frequency: frequencyList){
+            frequencies.add(frequency.toSwaggerObject());
+        }
+        data.setHaplotypeFrequencyList(frequencies);
+        if (qualityList != null){
+            List<io.swagger.model.Quality> qualities = new ArrayList<>();
+            for (Quality quality: qualityList){
+                qualities.add(quality.toSwaggerObject());
+            }
+            data.setQualityList(qualities);
+        }
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Label.java
+++ b/src/main/java/org/nmdp/hfcus/model/Label.java
@@ -1,0 +1,56 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Label {
+    public Label(){
+        //intentionally left empty
+    }
+
+    public Label(io.swagger.model.Label swaggerObject){
+        value = swaggerObject.getValue();
+        typeOfLabel = swaggerObject.getTypeOfLabel();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private String value;
+    private String typeOfLabel;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getTypeOfLabel() {
+        return typeOfLabel;
+    }
+
+    public void setTypeOfLabel(String typeOfLabel) {
+        this.typeOfLabel = typeOfLabel;
+    }
+
+    public io.swagger.model.Label toSwaggerObject(){
+        io.swagger.model.Label data = new io.swagger.model.Label();
+        data.setValue(value);
+        data.setTypeOfLabel(typeOfLabel);
+        return data;
+    }
+
+}

--- a/src/main/java/org/nmdp/hfcus/model/LabelSet.java
+++ b/src/main/java/org/nmdp/hfcus/model/LabelSet.java
@@ -1,0 +1,60 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.LabelData;
+import io.swagger.model.LabelList;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class LabelSet {
+    public LabelSet(){
+        //intentionally left empty
+    }
+
+    public LabelSet(LabelData swaggerObject) {
+        if (swaggerObject.getLabelList().getLabel() != null){
+            labelList = new ArrayList<>();
+            for (io.swagger.model.Label method : swaggerObject.getLabelList().getLabel() ){
+                labelList.add(new Label(method));
+            }
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Label> labelList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Label> getLabelList() {
+        return labelList;
+    }
+
+    public void setLabelList(List<Label> labelList) {
+        this.labelList = labelList;
+    }
+
+    public LabelData toSwaggerObject(){
+        LabelData data = new LabelData();
+        if (labelList != null){
+            List<io.swagger.model.Label> methods = new ArrayList<>();
+            for (Label label: labelList) {
+                methods.add(label.toSwaggerObject());
+            }
+            LabelList list = new LabelList();
+            list.setLabel(methods);
+            data.setLabelList(list);
+        }
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Method.java
+++ b/src/main/java/org/nmdp/hfcus/model/Method.java
@@ -1,0 +1,78 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Method {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private io.swagger.model.Method.TypeOfMethodEnum typeOfMethod;
+    private String methodValue;
+    private String methodComment;
+    private String methodReference;
+
+    public Method(){
+        //intentionally left empty
+    }
+
+    public Method(io.swagger.model.Method swaggerObject){
+        typeOfMethod = swaggerObject.getTypeOfMethod();
+        methodValue = swaggerObject.getMethodValue();
+        methodComment = swaggerObject.getMethodComment();
+        methodReference = swaggerObject.getMethodReference();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public io.swagger.model.Method.TypeOfMethodEnum getTypeOfMethod() {
+        return typeOfMethod;
+    }
+
+    public void setTypeOfMethod(io.swagger.model.Method.TypeOfMethodEnum typeOfMethod) {
+        this.typeOfMethod = typeOfMethod;
+    }
+
+    public String getMethodValue() {
+        return methodValue;
+    }
+
+    public void setMethodValue(String methodValue) {
+        this.methodValue = methodValue;
+    }
+
+    public String getMethodComment() {
+        return methodComment;
+    }
+
+    public void setMethodComment(String methodComment) {
+        this.methodComment = methodComment;
+    }
+
+    public String getMethodReference() {
+        return methodReference;
+    }
+
+    public void setMethodReference(String methodReference) {
+        this.methodReference = methodReference;
+    }
+
+    public io.swagger.model.Method toSwaggerObject(){
+        io.swagger.model.Method data = new io.swagger.model.Method();
+        data.setTypeOfMethod(typeOfMethod);
+        data.setMethodValue(methodValue);
+        data.setMethodComment(methodComment);
+        data.setMethodReference(methodReference);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/MethodSet.java
+++ b/src/main/java/org/nmdp/hfcus/model/MethodSet.java
@@ -1,0 +1,61 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.MethodData;
+import io.swagger.model.MethodList;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class MethodSet {
+
+    public MethodSet(){
+        //intentionally left empty
+    }
+
+    public MethodSet(MethodData swaggerObject) {
+        if (swaggerObject.getMethodList().getMethod() != null){
+            methodList = new ArrayList<>();
+            for (io.swagger.model.Method method : swaggerObject.getMethodList().getMethod() ){
+                methodList.add(new Method(method));
+            }
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Method> methodList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Method> getMethodList() {
+        return methodList;
+    }
+
+    public void setMethodList(List<Method> methodList) {
+        this.methodList = methodList;
+    }
+
+    public MethodData toSwaggerObject(){
+        MethodData data = new MethodData();
+        if (methodList != null){
+            List<io.swagger.model.Method> methods = new ArrayList<>();
+            for (Method method: methodList) {
+                methods.add(method.toSwaggerObject());
+            }
+            MethodList list = new MethodList();
+            list.setMethod(methods);
+            data.setMethodList(list);
+        }
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Population.java
+++ b/src/main/java/org/nmdp/hfcus/model/Population.java
@@ -1,0 +1,53 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.PopulationData;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.io.Serializable;
+
+@Entity
+public class Population implements Serializable {
+
+    public Population(){
+        //intentionally left empty
+    }
+
+    public Population(PopulationData swaggerObject){
+        if (swaggerObject.getId() != null){
+            id = swaggerObject.getId();
+        }
+        name = swaggerObject.getName();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+
+    private String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public PopulationData toSwaggerObject(){
+        PopulationData data = new PopulationData();
+        data.setId(id);
+        data.setName(name);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Quality.java
+++ b/src/main/java/org/nmdp/hfcus/model/Quality.java
@@ -1,0 +1,56 @@
+package org.nmdp.hfcus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.math.BigDecimal;
+
+@Entity
+public class Quality {
+    public Quality(){
+        //intentionally left empty
+    }
+
+    public Quality(io.swagger.model.Quality swaggerObject){
+        value = swaggerObject.getValue();
+        typeOfQuality = swaggerObject.getTypeOfQuality();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private Double value;
+    private io.swagger.model.Quality.TypeOfQualityEnum typeOfQuality;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(Double value) {
+        this.value = value;
+    }
+
+    public io.swagger.model.Quality.TypeOfQualityEnum getTypeOfQuality() {
+        return typeOfQuality;
+    }
+
+    public void setTypeOfQuality(io.swagger.model.Quality.TypeOfQualityEnum typeOfQuality) {
+        this.typeOfQuality = typeOfQuality;
+    }
+
+    public io.swagger.model.Quality toSwaggerObject(){
+        io.swagger.model.Quality data = new io.swagger.model.Quality();
+        data.setValue(value);
+        data.setTypeOfQuality(typeOfQuality);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Resolution.java
+++ b/src/main/java/org/nmdp/hfcus/model/Resolution.java
@@ -1,0 +1,57 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.ResolutionInfo;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Resolution {
+    public Resolution(){
+        //intentionally left empty
+    }
+
+    public Resolution(ResolutionInfo swaggerObject) {
+        scopeElement = swaggerObject.getScopeElement();
+        resolution = swaggerObject.getResolution();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    private String scopeElement;
+    private io.swagger.model.ResolutionInfo.ResolutionEnum resolution;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getScopeElement() {
+        return scopeElement;
+    }
+
+    public void setScopeElement(String scopeElement) {
+        this.scopeElement = scopeElement;
+    }
+
+    public ResolutionInfo.ResolutionEnum getResolution() {
+        return resolution;
+    }
+
+    public void setResolution(ResolutionInfo.ResolutionEnum resolution) {
+        this.resolution = resolution;
+    }
+
+    public ResolutionInfo toSwaggerObject(){
+        ResolutionInfo data = new ResolutionInfo();
+        data.setScopeElement(scopeElement);
+        data.setResolution(resolution);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Scope.java
+++ b/src/main/java/org/nmdp/hfcus/model/Scope.java
@@ -1,0 +1,67 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.ScopeElement;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Scope {
+    public Scope(){
+        //intentionally left empty
+    }
+    public Scope(ScopeElement swaggerObject) {
+        name = swaggerObject.getName();
+        freeName = swaggerObject.getFreeName();
+        typeOfScope = swaggerObject.getTypeOfScope();
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String scopeId;
+    private String name;
+    private String freeName;
+    private ScopeElement.TypeOfScopeEnum typeOfScope;
+
+    public String getScopeId() {
+        return scopeId;
+    }
+
+    public void setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getFreeName() {
+        return freeName;
+    }
+
+    public void setFreeName(String freeName) {
+        this.freeName = freeName;
+    }
+
+    public ScopeElement.TypeOfScopeEnum getTypeOfScope() {
+        return typeOfScope;
+    }
+
+    public void setTypeOfScope(ScopeElement.TypeOfScopeEnum typeOfScope) {
+        this.typeOfScope = typeOfScope;
+    }
+
+    public ScopeElement toSwaggerObject(){
+        ScopeElement data = new ScopeElement();
+        data.setName(name);
+        data.setFreeName(freeName);
+        data.setTypeOfScope(typeOfScope);
+        return data;
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/ScopeList.java
+++ b/src/main/java/org/nmdp/hfcus/model/ScopeList.java
@@ -1,0 +1,57 @@
+package org.nmdp.hfcus.model;
+
+import io.swagger.model.ScopeData;
+import io.swagger.model.ScopeElement;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class ScopeList {
+    public ScopeList(){
+        //intentionally left empty
+    }
+    public ScopeList(ScopeData swaggerObject) {
+        if (swaggerObject.getScopeElement() != null){
+            scopeList = new ArrayList<>();
+            for (ScopeElement scope: swaggerObject.getScopeElement()) {
+                scopeList.add(new Scope(scope));
+            }
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private String id;
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Scope> scopeList;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Scope> getScopeList() {
+        return scopeList;
+    }
+
+    public void setScopeList(List<Scope> scopeList) {
+        this.scopeList = scopeList;
+    }
+
+    public ScopeData toSwaggerObject(){
+        ScopeData data = new ScopeData();
+        if (scopeList != null){
+            List<ScopeElement> scopes = new ArrayList<>();
+            for (Scope scope: scopeList) {
+                scopes.add(scope.toSwaggerObject());
+            }
+            data.setScopeElement(scopes);
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
MongoDB didn't lend itself well to the way we specified the HFCu
interface. This adds classes and code to use the javax.persistance.*
annotations to use a relational database layer. Currently it is an
hibernate (in memory) database, but switching to another (like mysql)
database shouldn't be hard. The downside of hibernate is that data doesn't
persist between service restarts.

During the hackathon, I also worked on implementing the other endpoints,
so this is a complete prototype. It is still missing all kinds of access
control and checks (e.g. not null checks for the controller and much
more).

The changes in the `io.swagger` namespace come from a regeneration of server code due to adaptions of the swagger spec. I chose the `spring` server and I hope that was the correct choice...