### PR TITLE
Remove unused Population constructor

### DIFF
--- a/src/main/java/org/nmdp/hfcus/model/Population.java
+++ b/src/main/java/org/nmdp/hfcus/model/Population.java
@@ -15,13 +15,6 @@ public class Population implements Serializable {
         //intentionally left empty
     }
 
-    public Population(PopulationData swaggerObject){
-        if (swaggerObject.getId() != null){
-            id = swaggerObject.getId();
-        }
-        name = swaggerObject.getName();
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;


### PR DESCRIPTION
This is a remnant from before a separate `population` endpoint and not needed anymore.