### PR TITLE
Make java automatically validate required elements

### DIFF
--- a/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
+++ b/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
@@ -34,6 +34,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class HFCurationApiController implements HfcApi{
     }
 
     @Override
-    public ResponseEntity<HFCurationResponse> hfcPost(@RequestBody HFCurationRequest hfCurationRequest) {
+    public ResponseEntity<HFCurationResponse> hfcPost(@Valid @RequestBody HFCurationRequest hfCurationRequest) {
         if (hfCurationRequest != null) {
             HFCuration curation = new HFCuration(repositoryContainer, hfCurationRequest);
             curation = repositoryContainer.getCurationRepository().save(curation);


### PR DESCRIPTION
A baby step towards #15 as it adds automatics input validation on items marked as `required` in the swagger spec. It seems that some clients (like perl) send empty lists instead of leaving the list out, so some checks don't always triggers and need to implemented manually.