### PR TITLE
Manually create error 400

### DIFF
--- a/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
+++ b/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
@@ -3,6 +3,7 @@ package org.nmdp.hfcus.controller;
 import io.swagger.annotations.ApiParam;
 import io.swagger.api.HfcApi;
 import io.swagger.model.CohortData;
+import io.swagger.model.Error;
 import io.swagger.model.HFCurationListResponse;
 import io.swagger.model.HFCurationRequest;
 import io.swagger.model.HFCurationResponse;
@@ -27,10 +28,12 @@ import org.nmdp.hfcus.model.HFCuration;
 import org.nmdp.hfcus.model.LabelSet;
 import org.nmdp.hfcus.model.Population;
 import org.nmdp.hfcus.model.ScopeList;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -62,6 +65,13 @@ public class HFCurationApiController implements HfcApi{
         repositoryContainer.setHaplotypeFrequencySetRepository(haplotypeFrequencySetRepository);
         repositoryContainer.setAccessRepository(accessRepository);
         repositoryContainer.setScopeListRepository(scopeListRepository);
+    }
+
+    @ExceptionHandler(RequiredFieldInvalidException.class)
+    private ResponseEntity<Error> requiredFieldInvalidExceptionHandler(RequiredFieldInvalidException ex){
+        Error error = new Error();
+        error.setMessage(ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 
     @Override

--- a/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
+++ b/src/main/java/org/nmdp/hfcus/controller/HFCurationApiController.java
@@ -65,13 +65,6 @@ public class HFCurationApiController implements HfcApi{
         repositoryContainer.setScopeListRepository(scopeListRepository);
     }
 
-    @ExceptionHandler(RequiredFieldInvalidException.class)
-    private ResponseEntity<Error> requiredFieldInvalidExceptionHandler(RequiredFieldInvalidException ex){
-        Error error = new Error();
-        error.setMessage(ex.getMessage());
-        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
-    }
-
     private <T> ResponseEntity<T> RetrieveSubdataFromDatabase(Long submissionId, Function<HFCuration, ICurationDataModel<T>> converter){
         HFCuration curation = repositoryContainer.getCurationRepository().findOne(submissionId);
         ResponseEntity<T> responseEntity;

--- a/src/main/java/org/nmdp/hfcus/controller/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/org/nmdp/hfcus/controller/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,18 @@
+package org.nmdp.hfcus.controller;
+
+import io.swagger.model.Error;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class RestResponseEntityExceptionHandler{
+    @ExceptionHandler(RequiredFieldInvalidException.class)
+    private ResponseEntity<Error> requiredFieldInvalidExceptionHandler(RequiredFieldInvalidException ex){
+        Error error = new Error();
+        error.setMessage(ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/nmdp/hfcus/model/Access.java
+++ b/src/main/java/org/nmdp/hfcus/model/Access.java
@@ -1,6 +1,7 @@
 package org.nmdp.hfcus.model;
 
 import io.swagger.model.AccessData;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -15,6 +16,9 @@ public class Access {
 
     public Access(AccessData swaggerObject) {
         typeOfAccess = swaggerObject.getTypeOfAccess();
+        if (typeOfAccess == null){
+            throw new RequiredFieldInvalidException("Requires type of access");
+        }
     }
 
     @Id

--- a/src/main/java/org/nmdp/hfcus/model/Cohort.java
+++ b/src/main/java/org/nmdp/hfcus/model/Cohort.java
@@ -2,6 +2,7 @@ package org.nmdp.hfcus.model;
 
 
 import io.swagger.model.CohortData;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 
@@ -23,12 +24,17 @@ public class Cohort {
         if (swaggerObject.getGenotypeList() != null) {
             genotypeList = new GenotypeList(swaggerObject.getGenotypeList());
         }
+        else
+        {
+            throw new RequiredFieldInvalidException("Requires list of genotypes");
+        }
         name = swaggerObject.getName();
+        if (name == null){
+            throw new RequiredFieldInvalidException("Requires name for the cohort");
+        }
     }
 
-    public Long getId() {
-        return id;
-    }
+    public Long getId() { return id; }
 
     public void setId(Long id) {
         this.id = id;

--- a/src/main/java/org/nmdp/hfcus/model/Genotype.java
+++ b/src/main/java/org/nmdp/hfcus/model/Genotype.java
@@ -1,5 +1,7 @@
 package org.nmdp.hfcus.model;
 
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
+
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +22,9 @@ public class Genotype {
 
     public Genotype(io.swagger.model.Genotype swaggerObject){
         genotypeString = swaggerObject.getGenotypeString();
+        if (genotypeString == null){
+            throw new RequiredFieldInvalidException("Requires a genotype string");
+        }
         if (swaggerObject.getGenotypingMethods() != null){
             genotypingMethods = new ArrayList<>();
             for (io.swagger.model.GenotypeMethod method :swaggerObject.getGenotypingMethods()) {

--- a/src/main/java/org/nmdp/hfcus/model/HFCuration.java
+++ b/src/main/java/org/nmdp/hfcus/model/HFCuration.java
@@ -2,6 +2,7 @@ package org.nmdp.hfcus.model;
 
 import io.swagger.model.*;
 import org.nmdp.hfcus.dao.RepositoryContainer;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 
@@ -15,14 +16,14 @@ public class HFCuration implements Serializable {
         // intentionally left empty
     }
 
-    public HFCuration(RepositoryContainer repositoryContainer, HFCurationRequest data){
+    public HFCuration(RepositoryContainer repositoryContainer, HFCurationRequest data) {
         // Require a populationData ID
         if (data.getPopulationID() == null){
-            throw new RuntimeException("Requires Population ID");
+            throw new RequiredFieldInvalidException("Requires Population ID");
         }
         populationData = repositoryContainer.getPopulationRepository().findOne(data.getPopulationID());
         if (populationData == null) {
-            throw new RuntimeException("Not a valid Population ID");
+            throw new RequiredFieldInvalidException("Not a valid Population ID");
         }
         if (data.getCohortData() != null){
             cohortData = new Cohort(data.getCohortData());

--- a/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequency.java
+++ b/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequency.java
@@ -1,5 +1,7 @@
 package org.nmdp.hfcus.model;
 
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -16,7 +18,13 @@ public class HaplotypeFrequency {
     }
     public HaplotypeFrequency(io.swagger.model.HaplotypeFrequency swaggerObject) {
         haplotypeString = swaggerObject.getHaplotypeString();
+        if (haplotypeString == null){
+            throw new RequiredFieldInvalidException("requires a haplotype string");
+        }
         frequency = swaggerObject.getFrequency();
+        if (frequency == null){
+            throw new RequiredFieldInvalidException("requires a frequency");
+        }
         if (swaggerObject.getFrequencyErrorList() != null){
             errorList = new ArrayList<>();
             for (io.swagger.model.FrequencyError error: swaggerObject.getFrequencyErrorList()) {

--- a/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequencySet.java
+++ b/src/main/java/org/nmdp/hfcus/model/HaplotypeFrequencySet.java
@@ -4,6 +4,7 @@ import io.swagger.model.HaplotypeFrequencyData;
 import io.swagger.model.License;
 import io.swagger.model.ResolutionData;
 import io.swagger.model.ResolutionInfo;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -17,15 +18,28 @@ public class HaplotypeFrequencySet {
 
     public HaplotypeFrequencySet(HaplotypeFrequencyData swaggerObject){
         license = swaggerObject.getLicense().getTypeOfLicense();
+        if (license == null){
+            throw new RequiredFieldInvalidException("requires a license");
+        }
         if (swaggerObject.getResolutionData() != null) {
             resolutionList = new ArrayList<>();
             for (ResolutionInfo resolutionInfo :swaggerObject.getResolutionData()) {
                 resolutionList.add(new Resolution(resolutionInfo));
             }
         }
-        frequencyList = new ArrayList<>();
-        for (io.swagger.model.HaplotypeFrequency frequency: swaggerObject.getHaplotypeFrequencyList()) {
-            frequencyList.add(new HaplotypeFrequency(frequency));
+        List<io.swagger.model.HaplotypeFrequency> swaggerFrequencyList = swaggerObject.getHaplotypeFrequencyList();
+        if (swaggerFrequencyList != null) {
+            frequencyList = new ArrayList<>();
+            for (io.swagger.model.HaplotypeFrequency frequency: swaggerFrequencyList) {
+                frequencyList.add(new HaplotypeFrequency(frequency));
+            }
+            if (frequencyList.size() == 0){
+                throw new RequiredFieldInvalidException("frequency list must not be empty");
+            }
+        }
+        else
+        {
+            throw new RequiredFieldInvalidException("requires a frequency list");
         }
         if (swaggerObject.getQualityList() != null){
             qualityList = new ArrayList<>();

--- a/src/main/java/org/nmdp/hfcus/model/LabelSet.java
+++ b/src/main/java/org/nmdp/hfcus/model/LabelSet.java
@@ -2,6 +2,7 @@ package org.nmdp.hfcus.model;
 
 import io.swagger.model.LabelData;
 import io.swagger.model.LabelList;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -14,11 +15,18 @@ public class LabelSet {
     }
 
     public LabelSet(LabelData swaggerObject) {
-        if (swaggerObject.getLabelList().getLabel() != null){
+        if (swaggerObject.getLabelList() != null && swaggerObject.getLabelList().getLabel() != null){
             labelList = new ArrayList<>();
             for (io.swagger.model.Label method : swaggerObject.getLabelList().getLabel() ){
                 labelList.add(new Label(method));
             }
+            if (labelList.size() == 0){
+                throw new RequiredFieldInvalidException("label list must not be empty");
+            }
+        }
+        else
+        {
+            throw new RequiredFieldInvalidException("requires label list");
         }
     }
 

--- a/src/main/java/org/nmdp/hfcus/model/MethodSet.java
+++ b/src/main/java/org/nmdp/hfcus/model/MethodSet.java
@@ -2,6 +2,7 @@ package org.nmdp.hfcus.model;
 
 import io.swagger.model.MethodData;
 import io.swagger.model.MethodList;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -15,11 +16,18 @@ public class MethodSet {
     }
 
     public MethodSet(MethodData swaggerObject) {
-        if (swaggerObject.getMethodList().getMethod() != null){
+        if (swaggerObject.getMethodList() != null && swaggerObject.getMethodList().getMethod() != null){
             methodList = new ArrayList<>();
             for (io.swagger.model.Method method : swaggerObject.getMethodList().getMethod() ){
                 methodList.add(new Method(method));
             }
+            if (methodList.size() == 0){
+                throw new RequiredFieldInvalidException("method list must not be empty");
+            }
+        }
+        else
+        {
+            throw new RequiredFieldInvalidException("requires method list");
         }
     }
 

--- a/src/main/java/org/nmdp/hfcus/model/Population.java
+++ b/src/main/java/org/nmdp/hfcus/model/Population.java
@@ -1,6 +1,7 @@
 package org.nmdp.hfcus.model;
 
 import io.swagger.model.PopulationData;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -25,6 +26,9 @@ public class Population implements Serializable {
 
     public Population(String name, String description) {
         this.name = name;
+        if (this.name == null){
+            throw new RequiredFieldInvalidException("requires name");
+        }
         this.description = description;
     }
 

--- a/src/main/java/org/nmdp/hfcus/model/Quality.java
+++ b/src/main/java/org/nmdp/hfcus/model/Quality.java
@@ -1,5 +1,7 @@
 package org.nmdp.hfcus.model;
 
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,7 +15,13 @@ public class Quality {
 
     public Quality(io.swagger.model.Quality swaggerObject){
         value = swaggerObject.getValue();
+        if (value == null){
+            throw new RequiredFieldInvalidException("requires value");
+        }
         typeOfQuality = swaggerObject.getTypeOfQuality();
+        if (typeOfQuality == null){
+            throw new RequiredFieldInvalidException("requires typeOfQuality");
+        }
     }
 
     @Id

--- a/src/main/java/org/nmdp/hfcus/model/ScopeList.java
+++ b/src/main/java/org/nmdp/hfcus/model/ScopeList.java
@@ -2,6 +2,7 @@ package org.nmdp.hfcus.model;
 
 import io.swagger.model.ScopeData;
 import io.swagger.model.ScopeElement;
+import org.nmdp.hfcus.model.exceptions.RequiredFieldInvalidException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -18,6 +19,13 @@ public class ScopeList {
             for (ScopeElement scope: swaggerObject.getScopeElement()) {
                 scopeList.add(new Scope(scope));
             }
+            if (scopeList.size() == 0){
+                throw new RequiredFieldInvalidException("scopeList must not be empty");
+            }
+        }
+        else
+        {
+            throw new RequiredFieldInvalidException("requires scopeList");
         }
     }
 

--- a/src/main/java/org/nmdp/hfcus/model/exceptions/RequiredFieldInvalidException.java
+++ b/src/main/java/org/nmdp/hfcus/model/exceptions/RequiredFieldInvalidException.java
@@ -1,0 +1,7 @@
+package org.nmdp.hfcus.model.exceptions;
+
+public class RequiredFieldInvalidException extends RuntimeException {
+    public RequiredFieldInvalidException(String message){
+        super(message);
+    }
+}


### PR DESCRIPTION
This will check all required fields of the swagger spec in the model code and raise a `RequiredFieldInvalidException`. The API controller will then map the exception to an error 400 (bad request) and deliver it to the client.