### PR TITLE
Dockerization of application 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8 
+
+MAINTAINER Jason Brelsford or (jbrelsf@nmdp.org)
+
+WORKDIR /app
+
+EXPOSE 8080
+
+COPY ./target/service-haplotype-frequency-curation-0.0.1.jar /app/service-haplotype-frequency-curation-0.0.1.jar
+COPY bash-start-java-tomcat.sh /app/bash-start-java-tomcat.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ mvn clean package
 
 The project is setup to use mysql Docker instance for local development.
 ```bash
-cd db
 docker-compose up -d
 ```
 The phpMyAdmin page should be available at [http://localhost:9999/](http://localhost:9999/)

--- a/bash-start-java-tomcat.sh
+++ b/bash-start-java-tomcat.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo $MYSQL_DATABASE_URL
+echo $MYSQL_USER
+echo $MYSQL_PASSWORD
+sleep 10
+#java -Dspring.datasource.url="jdbc:mysql://db:3306/hfcusdb" -Dspring.datasource.username="hfcus_user" -Dspring.datasource.password="hfcus_user1" -jar /app/service-haplotype-frequency-curation-0.0.1.jar
+java -Dspring.datasource.url="$MYSQL_DATABASE_URL" -Dspring.datasource.username="$MYSQL_USER" -Dspring.datasource.password="$MYSQL_PASSWORD" -jar /app/service-haplotype-frequency-curation-0.0.1.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: '3.1'
 
 services:
+  web:
+    depends_on:
+      - db
+    image: curation:latest
+    container_name: curation-interface
+    restart: always
+    ports:
+      - 8080:8080
+    environment:
+      - MYSQL_DATABASE_URL=jdbc:mysql://db:3306/hfcusdb
+      - MYSQL_USER=hfcus_user
+      - MYSQL_PASSWORD=hfcus_user1
+    command:
+      - /app/bash-start-java-tomcat.sh
   db:
     image: mysql:5.6
     container_name: hfcus_mysql
@@ -14,7 +28,7 @@ services:
         MYSQL_USER: hfcus_user
         MYSQL_PASSWORD: hfcus_user1
     volumes:
-      - $PWD/:/docker-entrypoint-initdb.d
+      - $PWD/db:/docker-entrypoint-initdb.d
 
   phpmyadmin:
     image: phpmyadmin/phpmyadmin


### PR DESCRIPTION
Added Dockerfile and dockerized java -spring application.  Running docker-compose up from the root of the project will start all three dockers connected internally on docker network.  Check the docker-compose.yml and Dockerfile for details.