### PR TITLE
Make perl client usable

### DIFF
--- a/client/perl/.gitignore
+++ b/client/perl/.gitignore
@@ -1,1 +1,3 @@
 api/
+lib/WWW/SwaggerClient/
+swagger-codegen-cli.jar

--- a/client/perl/Cohort-client.pl
+++ b/client/perl/Cohort-client.pl
@@ -32,8 +32,11 @@ if($opt_local) {
 my $api_instance = WWW::SwaggerClient::CohortApi->new();
 my $genotype_list = WWW::SwaggerClient::Object::GenotypeList->new();
 my $cohort_request = WWW::SwaggerClient::Object::CohortRequest->new();
-$cohort_request->{name} = "Cohort1";
-$cohort_request->{genotype_list} = $genotype_list;
+my $cohort_data = WWW::SwaggerClient::Object::CohortData->new();
+$cohort_data->{name} = "Cohort1";
+$cohort_data->{genotype_list} = $genotype_list;
+
+$cohort_request->{cohort_data} = $cohort_data;
 
 $api_instance->{api_client}->{config}{base_url} = $base;
 $api_instance->{api_client}->{ua}->env_proxy;

--- a/client/perl/Cohort-client.pl
+++ b/client/perl/Cohort-client.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use lib 'lib';
+
+use Data::Dumper;
+use Getopt::Long;
+use File::Basename;
+
+use WWW::SwaggerClient::CohortApi;
+use WWW::SwaggerClient::Object::CohortRequest;
+
+my $base = "http://phycus.b12x.org:8080";
+my $opt_local;
+
+my $prg = basename($0);
+
+if (
+   !&GetOptions(
+      "local"    => \$opt_local,
+   )
+   )
+{
+   print "\n$prg: wrong option\n";
+   exit 1;
+}
+
+if($opt_local) {
+    $base = "http://localhost:8080";
+}
+
+my $api_instance = WWW::SwaggerClient::CohortApi->new();
+my $genotype_list = WWW::SwaggerClient::Object::GenotypeList->new();
+my $cohort_request = WWW::SwaggerClient::Object::CohortRequest->new();
+$cohort_request->{name} = "Cohort1";
+$cohort_request->{genotype_list} = $genotype_list;
+
+$api_instance->{api_client}->{config}{base_url} = $base;
+$api_instance->{api_client}->{ua}->env_proxy;
+
+eval {
+    my $result = $api_instance->create_cohort(cohort_request => $cohort_request
+);
+    print Dumper($result);
+    my $cohortId = $result->{id};
+    print "The Cohort ID is ${cohortId}\n";
+};
+if ($@) {
+    warn "Exception when calling CohortApi->create_cohort: $@\n";
+}

--- a/client/perl/HFCuS-client.pl
+++ b/client/perl/HFCuS-client.pl
@@ -137,7 +137,10 @@ sub push_haplotypes {
 
    # Use /population to create a new Population
    # See Population-client.pl
+   # Use /cohort to create a new Cohort
+   # See Cohort-client.pl
    $HFCurReq->{population_id} = 1;
+   $HFCurReq->{cohort_id} = 1;
    $HFCurReq->{haplotype_frequency_data} = $HapFreqData;
    my $response = $api_instance->hfc_post( hf_curation_request => $HFCurReq );
 

--- a/client/perl/HFCuS-client.pl
+++ b/client/perl/HFCuS-client.pl
@@ -72,7 +72,7 @@ if ( $action =~ /del_sub/i && !$submission_id ) {
 }
 
 my $api_instance = WWW::SwaggerClient::DefaultApi->new();
-$api_instance->{api_client}->{base_url} = $base;
+$api_instance->{api_client}->{config}{base_url} = $base;
 $api_instance->{api_client}->{ua}->env_proxy;
 print Dumper($api_instance) if $opt_verbose;
 

--- a/client/perl/Population-client.pl
+++ b/client/perl/Population-client.pl
@@ -1,14 +1,41 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use lib 'lib';
+
 use Data::Dumper;
-use WWW::SwaggerClient::Configuration;
+use Getopt::Long;
+use File::Basename;
+
 use WWW::SwaggerClient::PopulationApi;
 use WWW::SwaggerClient::Object::PopulationRequest;
+
+my $base = "http://phycus.b12x.org:8080";
+my $opt_local;
+
+my $prg = basename($0);
+
+if (
+   !&GetOptions(
+      "local"    => \$opt_local,
+   )
+   )
+{
+   print "\n$prg: wrong option\n";
+   exit 1;
+}
+
+if($opt_local) {
+    $base = "http://localhost:8080";
+}
 
 my $api_instance = WWW::SwaggerClient::PopulationApi->new();
 my $population_request = WWW::SwaggerClient::Object::PopulationRequest->new(); # PopulationRequest | Population Request
 $population_request->{name} = "CAU-US";
 $population_request->{description} = "US Caucasian";
 
-$api_instance->{api_client}->{base_url} = 'http://localhost:8080';
+$api_instance->{api_client}->{config}{base_url} = $base;
+$api_instance->{api_client}->{ua}->env_proxy;
 
 eval {
     my $result = $api_instance->create_population(population_request => $population_request);

--- a/client/perl/README.md
+++ b/client/perl/README.md
@@ -16,9 +16,20 @@ Install the following Perl libraries.
 - JSON
 
 ### Install API
-Generate and build the API. May require sudo. 
+Generate and build the API. The current client was tested with the swagger
+generator version `2.3.1`.
+
+#### For macOS
+Requires the `swagger-codegen` tool from homebrew. May require sudo. 
 ```
 sudo make
+```
+
+#### For Windows
+Using the powershell:
+```ps1
+Invoke-WebRequest -OutFile swagger-codegen-cli.jar http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar
+java -jar swagger-codegen-cli.jar generate --lang perl --input-spec ../../curation-swagger-spec.yaml
 ```
 
 ### Test the API 

--- a/client/perl/README.md
+++ b/client/perl/README.md
@@ -29,7 +29,7 @@ sudo make
 Using the powershell:
 ```ps1
 Invoke-WebRequest -OutFile swagger-codegen-cli.jar http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar
-java -jar swagger-codegen-cli.jar generate --lang perl --input-spec ../../curation-swagger-spec.yaml
+java -jar swagger-codegen-cli.jar generate --lang perl --input-spec ..\..\curation-swagger-spec.yaml
 ```
 
 ### Test the API 


### PR DESCRIPTION
With the inclusion of the Cohort API, I added a simple Cohort-client to the client. It's similar to the Population-client as it creates a nearly empty and hardcoded cohort. The HFCus-client was aapted o transmit data with cohort ID 1.

Using the current `swagger-codegen`, I discovered that there were some breaking changes in the generated code and adapted the client accordingly.

Additionally, I documented a possible setup on windows as it took some experimenting with the makefiles and such.