### PR TITLE
Update curation-swagger-spec.yaml

### DIFF
--- a/curation-swagger-spec.yaml
+++ b/curation-swagger-spec.yaml
@@ -788,10 +788,10 @@ definitions:
           - P
           - gNMDP
           - gDKMS
+          - 1-Field
           - 2-Field
+          - 3-Field
           - 4-Field
-          - 6-Field
-          - 8-Field
           - Serology
   FrequencyError:
     title: FrequencyError


### PR DESCRIPTION
Fixed the goofy "8-field" notion and its siblings in the yaml