### PR TITLE
Add building of docker image to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,5 +72,6 @@ workflows:
     jobs:
       - build:
           filters:
-            only: master
+            branches:
+              only: master
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,40 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/openjdk:8-jdk
-      
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
+
+      # build the package
+      - run: mvn clean package
+      - setup_remote_docker
+      - run: |
+          TAG=0.1.$CIRCLE_BUILD_NUM
+          docker build -t curation:$TAG .
+  test:
+    docker:
+      - image: circleci/openjdk:8-jdk
 
     working_directory: ~/repo
 
@@ -39,3 +66,9 @@ jobs:
         
       # run tests!
       - run: mvn integration-test
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,5 +70,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build
+      - build:
+          filters:
+            only: master
       - test


### PR DESCRIPTION
This PR adds the building of docker images of PHYCUS in circle CI if the commit was on the `master` branch.

The image is not pushed yet to a docker registry, but I would add that if it was something we wished. An automated deployment to a testing instance can't be done before the image is sent anywhere.

@jbrelsf2-nmdp @mmaiers-nmdp @pbashyal-nmdp 