### PR TITLE
Push docker image to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,16 @@ jobs:
 
       # build the package
       - run: mvn clean package
+      # build the docker image and tag it
       - setup_remote_docker
       - run: |
           TAG=0.1.$CIRCLE_BUILD_NUM
-          docker build -t curation:$TAG .
+          docker build -t frequency-curation:latest -t frequency-curation:$TAG .
+
+      # upload the docker image to docker hub
+      - run: |
+          docker login -u $DOCKER_USER -p $DOCKER_PASS
+          docker push nmdpbioinformatics/frequency-curation
   test:
     docker:
       - image: circleci/openjdk:8-jdk


### PR DESCRIPTION
Built docker images should be pushed to docker hub now. **However**, we'll need to add the variables `DOCKER_USER` and `DOCKER_PASS` of a user with push ability to the project settings at https://circleci.com/gh/nmdp-bioinformatics/service-haplotype-frequency-curation/edit#env-vars before merging this.