### PR TITLE
add population ID to import client

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -7,6 +7,7 @@ Use `make` to generate and install the sample HFCus client package and scripts l
 `api/bin`
 
 Use `--help` option to get help.
+
 ```
 $ api/bin/hfcus-import --help
 usage: hfcus-import [-h] [-u URL] [-f FREQFILE] [-c CONFIG] [-v VERBOSE]
@@ -27,12 +28,14 @@ See `config.json` for a sample config file.
 Make sure the population exists and is a valid id in config.json 
 Eg. check [Population API http://localhost:8080/population](http://localhost:8080/population) for the ID. 
 
+
 To locally import the frequencies:
 ```
 api/bin/hfcus-import -u http://localhost:8080/ -f ../perl/data/US_CAU.freqs -c config.json
 ```
 
 Similarly to extract:
+
 ```
  api/bin/hfcus-extract -u http://localhost:8080/ -s 1 -o hfcout.txt
 ```

--- a/client/python/config.json
+++ b/client/python/config.json
@@ -1,6 +1,7 @@
 {
-	"resolution": "G",
+	"resolution": "gNMDP",
 	"license_type": "CC0",
-	"population_id": 1
+	"population_id": 1,
+	"cohort_id": 1
 }
 

--- a/client/python/hfcus-import
+++ b/client/python/hfcus-import
@@ -62,6 +62,7 @@ def main():
     license = License(type_of_license=license_type)
 
     pop_id = config['population_id']
+    cohort_id = config['cohort_id']
 
     resolution = config['resolution']
     resinfo = [ResolutionInfo(resolution=resolution)]
@@ -80,10 +81,12 @@ def main():
                         haplotype_frequency_list=hapfreqs,
                         resolution_data=resinfo)
 
-    cur_request = HFCurationRequest(population_id=pop_id,
+    cur_request = HFCurationRequest(population_id=pop_id, cohort_id=cohort_id,
                                     haplotype_frequency_data=hapfreqdata)
 
-    response = api_instance.hfc_post(hf_curation_request=cur_request)
+    print(cur_request)
+    #response = api_instance.hfc_post(hf_curation_request=cur_request)
+    response = api_instance.hfc_post(cur_request)
 
     print(response)
 


### PR DESCRIPTION
The python client has an import script that didn't work because it was not passing in population ID (which is now mandatory).  I also fixed a formatting problem in the README.md and updated the config file to have population ID 