### PR TITLE
Addition of metadata schema check and checking resolution compliance

### DIFF
--- a/hfx/json/README.md
+++ b/hfx/json/README.md
@@ -3,7 +3,7 @@
 To run: 
 `python mkhfx.py` 
 
-Needs installation of requests and pandas
+Needs installation of requests, pandas, jsonschema, py-ard
 
 This script will read the config file to get the actual file paths to produce hfx output
 There are two different configs activating different modes of the program:

--- a/hfx/json/mkhfx.py
+++ b/hfx/json/mkhfx.py
@@ -154,7 +154,7 @@ def check_loci_order(hapfreqs, loci):
     loci_dict = {locus['locus']: locus for locus in loci}
     loci_metadata_ordered = [
         loci_dict[f"HLA-{locus}"]
-        if "HLA" not in locus else loci_dict[locus]
+        if "HLA" not in locus and f"HLA-{locus}" in loci_dict else loci_dict[locus]
         for locus in input_loci_split
     ]
     return loci_metadata_ordered

--- a/hfx/json/mkhfx.py
+++ b/hfx/json/mkhfx.py
@@ -12,6 +12,8 @@ import argparse
 import os
 import requests
 import pandas as pd
+from jsonschema import validate
+import pyard
 
 # request header
 requestHeader = {
@@ -19,26 +21,28 @@ requestHeader = {
   "X-Requested-With": "XMLHttpRequest"
 }
 
-# File path defaults
-hapfreq_file = '../data/US_CAU.freqs'
-json_file = './hfx.json'
-schema_file = './hfx.schema.json'
-metadata_file = './hfx.metadata.json'
+PYARD_RESOLUTION_EQUIVS = {
+    'G': 'G',
+    'P': 'P',
+    'g': 'lg', 
+    '4-Field': 'W',
+    '3-Field': 'exon',
+    '2-Field': 'U2',
+    'Serology': 'S',
+}
 
 def load_hapfreq_dataframe(path, afnd_input=False):
     if afnd_input:
         return get_hapfreqs_from_AFND(path)
-    else:
-        return pd.read_csv(path, header=None, index_col=None)
+    return pd.read_csv(path, header=None, index_col=None)
+
 
 # Function to get the haplotype frequencies from a pandas dataframe
 def extract_hapfreqs(df, percentageToFloat=False):
-
     # Get the haplotype and frequency columns and return those rows as a list
     haploColumn = 0
     freqColumn = 1
-    for colIndex in range(0, len(df.columns)):
-        col = df.columns[colIndex]
+    for colIndex, col in enumerate(df.columns):
         if isinstance(col, str):
             if 'freq' in col.lower():
                 freqColumn = colIndex
@@ -50,23 +54,39 @@ def extract_hapfreqs(df, percentageToFloat=False):
         'frequency': float(row[freqColumn+1] / (100 if percentageToFloat else 1))
     } for row in df.itertuples()]
 
+
 def get_hapfreqs_from_AFND(url):
-  result = requests.get(url, headers=requestHeader, timeout=None)
-  hfs = pd.read_html(result.text, attrs={'class':'tblNormal'})[0]
-  return hfs
+    result = requests.get(url, headers=requestHeader, timeout=None)
+    hfs = pd.read_html(result.text, attrs={'class':'tblNormal'})[0]
+    return hfs
+
+
+def check_metadata_schema(metadata):
+    "Check that the input metadata complies with schema."
+
+    with open("./hfx.schema.json", 'r', encoding='utf-8') as metadata_schema_file:
+        metadata_schema = json.load(metadata_schema_file)
+    if 'metaData' not in metadata:
+        raise ValueError("metaData not found in the metadata file")
+
+    try:
+        validate(instance=metadata['metaData'], schema=metadata_schema['properties']['metaData'])
+    except Exception as e:
+        raise ValueError(f"Metadata validation failed: {e}") from e
+
 
 def get_metadata(df_or_metadata_path):
-    
     # Load the metadata JSON to understand the structure of metaData
     if isinstance(df_or_metadata_path, str):
         metadata_path = df_or_metadata_path
         with open(metadata_path, 'r', encoding='utf-8') as metadata_file:
             metadata_data = json.load(metadata_file)
+        check_metadata_schema(metadata_data)
         return metadata_data["metaData"]
 
     # if a dataframe is provided, the metadata is created with information from there before returning 
-    elif isinstance(df_or_metadata_path, pd.DataFrame):    
-        df = df_or_metadata_path    
+    if isinstance(df_or_metadata_path, pd.DataFrame):
+        df = df_or_metadata_path
         metadata = {}
         metadata['outputResolution'] = []
         metadata['cohortDescription'] = {}
@@ -100,7 +120,8 @@ def get_metadata(df_or_metadata_path):
                 # or otherwise put it at 'variable'
                 metadata['outputResolution'] = []
                 for locus_allele in longestSplitHaplo:
-                    metadata['outputResolution'].append({'locus': locus_allele.split('*')[0], 'resolution': get_resolution(locus_allele)})
+                    metadata['outputResolution'].append(
+                        {'locus': locus_allele.split('*')[0], 'resolution': get_resolution(locus_allele)})
 
             # TODO: Somehow get the geocode
             elif 'population' in col.lower():
@@ -110,12 +131,71 @@ def get_metadata(df_or_metadata_path):
 
     return metadata
 
+
 # TODO: Actually implement this
 def get_resolution(allele):
     return None
 
+def check_loci_order(hapfreqs, loci):
+    required_loci = set(locus['locus'].split('HLA-')[-1] for locus in loci)
+    input_loci = [
+        [allele.split('*')[0] for allele in hapfreq['haplotype'].split('~')]
+        for hapfreq in hapfreqs
+    ]
+    input_loci_order = set("~".join(locus) for locus in input_loci)
+
+    if len(input_loci_order) > 1:
+        raise ValueError("Order of loci in haplotypes inconsistent.")
+    input_loci_split = list(input_loci_order)[0].split("~")
+    if set(input_loci_split) != required_loci:
+        raise ValueError(f"Input loci doesn't match the metadata loci. Input loci: {input_loci_split}, Metadata loci: {required_loci}")
+
+    # Reorder loci to match input_loci_order
+    loci_dict = {locus['locus']: locus for locus in loci}
+    loci_metadata_ordered = [
+        loci_dict[f"HLA-{locus}"]
+        if "HLA" not in locus else loci_dict[locus]
+        for locus in input_loci_split
+    ]
+    return loci_metadata_ordered
+
+
+def check_resolution(hapfreqs, loci, nomenclature):
+    if nomenclature['kind']=='imgt':
+        ard = pyard.init(nomenclature['version'].replace('.',''))
+    # TODO: Add support for other accepted nomenclatures (currently 'ipd')
+
+
+    elif nomenclature['kind']=='ipd':
+        raise ValueError("IPD nomenclature not yet supported")
+
+    hapfreqs_split = [hapfreq['haplotype'].split('~') for hapfreq in hapfreqs]
+    for i, locus in enumerate(loci):
+        resolution = locus['resolution']
+        if resolution=='g':
+            # TODO
+            print("g resolution validation not yet supported (issue reported in py-ard repo)")
+            continue
+        if resolution=='1-Field':
+            # TODO
+            print("1-field resolution validation not yet developed")
+            continue
+
+        locus_alleles = set(hapfreq[i] for hapfreq in hapfreqs_split)
+        for locus_allele in locus_alleles:
+            if resolution in PYARD_RESOLUTION_EQUIVS:
+                try:
+                    ard.redux(locus_allele, PYARD_RESOLUTION_EQUIVS[resolution])
+                except Exception as e:
+                    raise ValueError(f"Resolution check failed for {locus_allele} at {resolution} resolution: {e}") from e
+
+
+def check_hapfreqs_metadata(hapfreqs, metadata):
+    loci_metadata_ordered = check_loci_order(hapfreqs, metadata['outputResolution'])
+    check_resolution(hapfreqs, loci_metadata_ordered, metadata['nomenclatureUsed'])
+
+
 def save_to_hfx(output_hfx_file, frequency_data, metadata):
-    
     # Create final JSON structure
     final_data = {
         "metaData": metadata,
@@ -126,15 +206,29 @@ def save_to_hfx(output_hfx_file, frequency_data, metadata):
     with open(output_hfx_file, 'w', encoding='utf-8') as output_hfx:
         json.dump(final_data, output_hfx, indent=4)
 
-def __main__():
+
+def get_parser():
+    """Get arguments from argparser."""
+
     parser = argparse.ArgumentParser(description='configfile')
-    parser.add_argument('--conf', required=True, default='config.json', help="Config file with locations of files")
+    parser.add_argument(
+        '--conf',
+        required=True,
+        default='config.json',
+        help="Config file with locations of files"
+    )
     args = parser.parse_args()
+    return args
+
+def main():
+    args = get_parser()
 
     # Load config file
     if os.path.exists(args.conf):
-        with open(args.conf, 'rt') as f:
+        with open(args.conf, 'rt', encoding='utf-8') as f:
             config = json.load(f)
+    else:
+        exit("Config file not found")
 
     # Get the output file name
     if config.get('output_hfx_file', False):
@@ -166,8 +260,13 @@ def __main__():
     # load the metadata
     metadata = get_metadata(hapfreq_df if afnd_input else metadata_file)
 
+    # Sense check hapfreqs and metadata compatibility, 
+    # not tested on AFND input, TODO
+    check_hapfreqs_metadata(hapfreqs, metadata)
+
     # Combine both and save to hfx
     save_to_hfx(output_hfx_file, hapfreqs, metadata)
 
-__main__()
 
+if __name__ == "__main__":
+    main()

--- a/hfx/json/requirements.txt
+++ b/hfx/json/requirements.txt
@@ -9,3 +9,5 @@ requests==2.32.3
 six==1.16.0
 tzdata==2024.2
 urllib3==2.2.3
+jsonschema==4.23.0
+pyard==1.5.3


### PR DESCRIPTION
As part of DaSH 17 worked on adding in some functionality to the mkhpx.py script. 

First, using jsonschema to check the provided metadata json complies with the hfx.schema.json. 

Second, adding some sense checking that the haplotype frequencies provided match what has been claimed in the metadata:

- loci order in the haplotypes is consistent and have all been declared
- checking that the resolution of alleles for a locus is valid using py-ard where possible (all except 'g' and '1-Field' should work at the moment where nomenclatureUsed is 'imgt')